### PR TITLE
Use array_key_exists instead of isset for "_findVariableInContext"

### DIFF
--- a/Mustache.php
+++ b/Mustache.php
@@ -608,7 +608,7 @@ class Mustache {
 				} else if (isset($view->$tag_name)) {
 					return $view->$tag_name;
 				}
-			} else if (isset($view[$tag_name])) {
+			} else if (array_key_exists ($tag_name, $view)) {
 				return $view[$tag_name];
 			}
 		}


### PR DESCRIPTION
A bit of information on this bug.

Say I have a class with a $description property, value being the meta description of a website.

Now I have a form method in a child view class that returns an array with form values. Like

```
public function form()
{
    $default = array
    (
        'name'        => NULL,
        'description' => NULL,
        'tags'        => NULL,
    );

    return array_intersect_key($this->form, $default);
}
```

The initial page load would set the description value to that of the meta description (even though the key is set). This is because isset returns false for an array key that has a NULL value. `array_key_exists` solves this problem nicely.
