### PR TITLE
Use is_callable instead of method_exists

### DIFF
--- a/Mustache.php
+++ b/Mustache.php
@@ -603,7 +603,7 @@ class Mustache {
 	protected function _findVariableInContext($tag_name, $context) {
 		foreach ($context as $view) {
 			if (is_object($view)) {
-				if (method_exists($view, $tag_name)) {
+				if (is_callable(array($view, $tag_name))) {
 					return $view->$tag_name();
 				} else if (isset($view->$tag_name)) {
 					return $view->$tag_name;


### PR DESCRIPTION
To allow objects implementing __call().

Closes #18.
