### PR TITLE
Adding Pipes

### DIFF
--- a/Mustache.php
+++ b/Mustache.php
@@ -56,7 +56,7 @@ class Mustache {
 	 * Constants used for section and tag RegEx
 	 */
 	const SECTION_TYPES = '\^#\/';
-	const TAG_TYPES = '#\^\/=!<>\\{&';
+	const TAG_TYPES = '#\^\/=!<>\\{&|';
 
 	protected $_otag = '{{';
 	protected $_ctag = '}}';
@@ -557,6 +557,9 @@ class Mustache {
 			case '!':
 				return $this->_renderComment($tag_name, $leading, $trailing);
 				break;
+			case '|':
+				return $this->_renderJson($tag_name, $leading, $trailing);
+				break;
 			case '>':
 			case '<':
 				return $this->_renderPartial($tag_name, $leading, $trailing);
@@ -635,6 +638,24 @@ class Mustache {
 			return $this->_stringHasR($leading, $trailing) ? "\r\n" : "\n";
 		}
 		return $leading . $trailing;
+	}
+	
+	/**
+	 * Return the requested tag as JSON.
+	 *
+	 * @access protected
+	 * @param string $tag_name
+	 * @param string $leading Whitespace
+	 * @param string $trailing Whitespace
+	 * @return string
+	 */
+	protected function _renderJson($tag_name, $leading, $trailing) {
+		$v = $this->_getVariable($tag_name);
+		$v = $v && !$v instanceof Closure ? $v : array();
+		$v = is_array($v) || is_object($v) ? $v : array($v);
+		$v = json_encode($v);
+		$v = strlen($v) > 0 ? $v : json_encode(array());
+		return $leading . $v . $trailing;
 	}
 
 	/**

--- a/test/MustachePipeTest.php
+++ b/test/MustachePipeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+require_once '../Mustache.php';
+
+/**
+ * @group pragmas
+ */
+class MustachePipeTest extends PHPUnit_Framework_TestCase {
+
+	public function testObjects() {
+		$data = array('foo' => (object)array('bar' => 'baz'));
+		$template = '{{|foo}}';
+		$output = '{"bar":"baz"}';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+	
+	public function testArrays() {
+		$data = array('foo' => array('bar' => 'baz'));
+		$template = '{{|foo}}';
+		$output = '{"bar":"baz"}';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+	
+	public function testStrings() {
+		$data = array('foo' => 'bar');
+		$template = '{{|foo}}';
+		$output = '["bar"]';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+	
+	public function testLists() {
+		$data = array('foo' => array('bar','baz'));
+		$template = '{{|foo}}';
+		$output = '["bar","baz"]';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+	
+	public function testFalsy() {
+		$data = array('foo' => false);
+		$template = '{{|foo}}';
+		$output = '[]';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+	
+	public function testUnrenderables() {
+		$data = array('foo' => function(){return "bar";});
+		$template = '{{|foo}}';
+		$output = '[]';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+
+}


### PR DESCRIPTION
Pipe tags represent context items that should be rendered as JSON.
The tag's content may contain the name of any context which is renderable as JSON.

See spec
https://github.com/mustache/spec/pull/16
