### PR TITLE
Adding Special Sections

### DIFF
--- a/Mustache.php
+++ b/Mustache.php
@@ -238,7 +238,11 @@ class Mustache {
 
 				// regular section
 				case '#':
-					if ($this->_varIsIterable($val)) {
+					if ($tag_name=='!') {
+						$rendered_content = '';
+					} else if ($tag_name=='`') {
+						$rendered_content = $content;
+					} else if ($this->_varIsIterable($val)) {
 						foreach ($val as $local_context) {
 							$this->_pushContext($local_context);
 							$rendered_content .= $this->_renderTemplate($content);
@@ -255,7 +259,6 @@ class Mustache {
 					}
 					break;
 			}
-
 			return $rendered_before . $rendered_content . $this->_renderTemplate($after);
 		}
 

--- a/test/MustacheSpecialSectionTest.php
+++ b/test/MustacheSpecialSectionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+require_once '../Mustache.php';
+
+/**
+ * @group pragmas
+ */
+class MustacheSpecialSectionTest extends PHPUnit_Framework_TestCase {
+
+	// Comments
+
+	public function testCommentSingleLine() {
+		$data = array();
+		$template = '{{#!}}Over {{/!}}Here';
+		$output = 'Here';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+
+	public function testCommentIgnoreTags() {
+		$data = array('bro' => 'dawg');
+		$template = '{{#!}}Don\'t render me, {{bro}}.{{/!}}';
+		$output = '';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+
+	public function testCommentMultiLine() {
+		$data = array();
+		$template = '|
+        | This Is
+          {{#!}}
+        Not
+          {{/!}}
+        | A Line';
+		$output = '|
+        | This Is
+        | A Line';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+
+	// Literals
+	
+	public function testLiteralSingleLine() {
+		$data = array();
+		$template = '{{#`}}Over {{/`}}Here';
+		$output = 'Over Here';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+	
+	public function testLiteralIgnoreTags() {
+		$data = array('bro' => 'dawg');
+		$template = '{{#`}}Don\'t render me, {{bro}}.{{/`}}';
+		$output = 'Don\'t render me, {{bro}}.';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+	
+	public function testLiteralMultiLine() {
+		$data = array('foo' => array('bar' => 'baz'));
+		$template = '|
+        | var template = "
+          {{#`}}
+        | {{#foo}}
+        |   {{bar}}
+        | {{/foo}}
+          {{/`}}
+        | ";';
+		$output = '|
+        | var template = "
+        | {{#foo}}
+        |   {{bar}}
+        | {{/foo}}
+        | ";';
+		$m = new Mustache();
+		$this->assertEquals($output, $m->render($template, $data));
+	}
+
+}


### PR DESCRIPTION
Special section tags do not contain content referring to a context and therefore do no require name resolution:
  1) If the name is "!", the section is a comment block.
  2) If the name is "`", the section is a literal block.

See spec
https://github.com/mustache/spec/pull/18
