### PR TITLE
Allow user to turn off UNKNOWN_PRAGMA checking

### DIFF
--- a/Mustache.php
+++ b/Mustache.php
@@ -403,7 +403,10 @@ class Mustache {
 		$options_string = $matches['options_string'];
 
 		if (!in_array($pragma_name, $this->_pragmasImplemented)) {
-			throw new MustacheException('Unknown pragma: ' . $pragma_name, MustacheException::UNKNOWN_PRAGMA);
+			if($this->_throwsException(MustacheException::UNKNOWN_PRAGMA))
+				throw new MustacheException('Unknown pragma: ' . $pragma_name, MustacheException::UNKNOWN_PRAGMA);
+			else
+				return '';
 		}
 
 		$options = array();
@@ -448,7 +451,10 @@ class Mustache {
 	 */
 	protected function _getPragmaOptions($pragma_name) {
 		if (!$this->_hasPragma($pragma_name)) {
-			throw new MustacheException('Unknown pragma: ' . $pragma_name, MustacheException::UNKNOWN_PRAGMA);
+			if($this->_throwsException(MustacheException::UNKNOWN_PRAGMA))
+				throw new MustacheException('Unknown pragma: ' . $pragma_name, MustacheException::UNKNOWN_PRAGMA);
+			else
+				return array();
 		}
 
 		return (is_array($this->_localPragmas[$pragma_name])) ? $this->_localPragmas[$pragma_name] : array();


### PR DESCRIPTION
We were using your Mustache.php(good work) and had quite a few templates sitting around.

We wrote those templates a while back -- so they referenced some old pragmas, e.g. DOT-NOTATION and IMPLICIT-ITERATOR, that aren't valid any more.

We use the same Mustache templates in different languages and some of the other implementations require those pragmas -- so being able to turn off unknown pragma checking is important to us.

There was a _throwsException config option for the unknown pragma exception but it seems that when the exceptions are actually thrown, it's not being checked.

This patch seemed to work well for us.

I don't have a test for it -- I hacked it together quickly and have to get back to some other things but you can test the behavior by including an invalid pragma in a template with and without my patch.

Thanks!
