### PR TITLE
Allow __call handle requests for view methods.

### DIFF
--- a/Mustache.php
+++ b/Mustache.php
@@ -795,7 +795,7 @@ class Mustache {
 					return $view->$tag_name();
 				} else if (isset($view->$tag_name)) {
 					return $view->$tag_name;
-				} else {
+				} else if (method_exists($view, '__call')) {
 					$var = @$view->$tag_name();
 					if ($var) {
 						return $var;


### PR DESCRIPTION
In the case where `method_exists($view, $tag_name)` fails _and_ when `isset($view->$tag_name)` fails, this patch alters Mustache to attempt to call the method anyway. This allows the view to use `__call` to handle the method invocation.

Example:

```
class MyModel {
    public function baz() {
        return "baz";
    }
}
```

``` php
class MyView {
    public $foo = "foo";

    public function bar() {
        return "bar";
    }
}
```

``` php
class View {
    protected $_model;

    public function __construct($model) {
        $this->_model = $model;
    }

    public function __call($name, $args) {
        return call_user_func_array(array($this->_model, $name), $args);
    }
}
```

In this scenario, if we pass an instance of `MyView` to Mustache, then `foo`, `bar` and `baz` are all available.
