### PR TITLE
Add a test to discourage people from implementing support for __call.

### DIFF
--- a/test/MustacheCallTest.php
+++ b/test/MustacheCallTest.php
@@ -1,0 +1,24 @@
+<?php
+
+require_once '../Mustache.php';
+
+class MustacheCallTest extends PHPUnit_Framework_TestCase {
+
+	public function testCallEatsContext() {
+		$foo = new Foo();
+		$foo->name = 'Bob';
+
+		$template = '{{# foo }}{{ label }}: {{ name }}{{/ foo }}';
+		$data = array('label' => 'name', 'foo' => $foo);
+		$m = new Mustache($template, $data);
+
+		$this->assertEquals('name: Bob', $m->render());
+	}
+}
+
+class Foo {
+	public $name;
+	public function __call($method, $args) {
+		return 'unknown value';
+	}
+}


### PR DESCRIPTION
Pull in the test from https://gist.github.com/655784

This should discourage reports like #16, #19 and #55, and #76.
