### PR TITLE
Added functionality to generate hash of values from template

### DIFF
--- a/Mustache.php
+++ b/Mustache.php
@@ -857,6 +857,61 @@ class Mustache {
 	protected function _varIsCallable($var) {
 	  return !is_string($var) && is_callable($var);
 	}
+	
+	/**
+	 * Generate a hash of expected values from a given template
+	 *
+	 * @access public
+	 * @param string $template (default: null)
+	 * @return array hash of expected variables
+	 */
+	public function generateHash($template = null) {
+		$template = ($template)?
+			$template :
+			$this->_template;
+    
+		//Extract all variables from the template
+		preg_match_all('/{{([^}]+)/',$template,$matches);
+    $tags = $matches[1];
+    
+    //Turn the resulting flat array into a multidimensional one
+    $i = 0;
+    return $this->_tagsToHash($tags, $i);
+	}
+
+  /**
+  * Private helper function for generateHash
+  * Turns flat array of tags into multidimensional array
+  *
+  * @author Philip Schweiger <pschwei1@gmail.com>, with assistance on 
+  * recursion logic from khael on SO (http://stackoverflow.com/users/926474/)
+  * @access private
+  * @param array $tags flat array of tags
+  * @param int &$i current index value as function loops through $tags
+  * @param string $current_tag
+  */
+  private function _tagsToHash($tags, &$i, $current_tag = '') {
+    $nested = array();
+    $tot = count($tags);	
+    while ($i < $tot):
+      $tag = $tags[$i];
+		
+      if ($tag[0] === '/') {
+        $i++;
+        return $nested;
+      } elseif ($tag[0] === '#') {
+        $tag = str_replace('#','',$tag);
+        $i++;
+        $nested[$tag] = $this->_tagsToHash($tags, $i, $tag);
+      } else {
+        $nested[$tag] = '';
+        $i++;
+      }
+    endwhile;
+    return $nested;
+  }
+
+
 }
 
 

--- a/examples/makehash/index.php
+++ b/examples/makehash/index.php
@@ -1,0 +1,59 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+	<meta charset="UTF-8">
+	<title>Mustache Example: make hash</title>
+</head>
+<body>
+	<h1>Mustache Example: make hash</h1>
+	
+	<p>Most Mustache examples take a hash and use it to populate the variables in a template. This one goes the other way &ndash; assuming you have a template with mustache variables, it will generate an empty hash.</p>
+	
+	<p>This is useful for cases where the person writing the template and the person who will be using it are not the same person, and you need a quick and easy way to let the person populating the template know what variables are expected.</p>
+	
+	<h2>The Template</h2>
+	
+	<p>Here is our template:</p>
+	
+	<pre>
+	&lt;h1>{{header}}&lt;/h1>
+{{#bug}}
+{{/bug}}
+
+{{#items}}
+  {{#first}}
+    &lt;li>&lt;strong>{{name}}&lt;/strong>&lt;/li>
+  {{/first}}
+  {{#link}}
+    &lt;li>&lt;a href="{{url}}">{{name}}&lt;/a>&lt;/li>
+  {{/link}}
+{{/items}}
+
+{{#empty}}
+  &lt;p>The list is empty.&lt;/p>
+{{/empty}}
+	</pre>
+	
+	<h2>The Code</h2>
+	
+	<p>Run the template through Mustache <br />
+	(assume that we have assigned the above template to the variable $template):</p>
+	
+	<pre>
+	$m = new Mustache($template);
+	//Returns an associative array - format as json for output purposes
+	echo json_encode($m->generateHash());
+	</pre>
+	
+	<h2>The Result</h2>
+	
+	<pre>
+<?php
+require_once '../../Mustache.php';
+$template = file_get_contents('template.txt');
+$m = new Mustache($template);
+echo json_encode($m->generateHash());
+?>	
+	</pre>
+</body>
+</html>

--- a/examples/makehash/template.txt
+++ b/examples/makehash/template.txt
@@ -1,0 +1,16 @@
+<h1>{{header}}</h1>
+{{#bug}}
+{{/bug}}
+
+{{#items}}
+  {{#first}}
+    <li><strong>{{name}}</strong></li>
+  {{/first}}
+  {{#link}}
+    <li><a href="{{url}}">{{name}}</a></li>
+  {{/link}}
+{{/items}}
+
+{{#empty}}
+  <p>The list is empty.</p>
+{{/empty}}


### PR DESCRIPTION
Hey - I had a need to do a reverse Mustache - take a template, and generate the hash of expected values. Useful for when a developer needs to quickly and easily know what values a template takes. I added this feature, but this is my first attempt at a pull request, so I'm not sure i'm doing this right - I originally did it in the master branch of my fork, but then realized I should maybe do it in the branch feature/makeHash. Not sure if pull requests are per branch or per repo, so I'm not entirely sure what you'll receive here.

Also, I wasn't sure what kind of unit tests would be appropriate, so that's missing. The example is a viewable example, which is different from what your examples look like - so feel free to take or leave that.

Hope this feature is helpful to others!
