### PR TITLE
Add a "helpers" implementation to 2.0-dev

### DIFF
--- a/src/Mustache/HelperCollection.php
+++ b/src/Mustache/HelperCollection.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of Mustache.php.
+ *
+ * (c) 2012 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mustache;
+
+/**
+ * A collection of helpers for a Mustache instance.
+ */
+class HelperCollection {
+	private $helpers = array();
+
+	/**
+	 * Helper Collection constructor.
+	 *
+	 * Optionally accepts an array (or \Traversable) of `$name => $helper` pairs.
+	 *
+	 * @throws \InvalidArgumentException if the $helpers argument isn't an array or \Traversable
+	 *
+	 * @param array|Traversable $helpers (default: null)
+	 */
+	public function __construct($helpers = null) {
+		if ($helpers !== null) {
+			if (!is_array($helpers) && !$helpers instanceof \Traversable) {
+				throw new \InvalidArgumentException('HelperCollection constructor expects an array of helpers');
+			}
+
+			foreach ($helpers as $name => $helper) {
+				$this->add($name, $helper);
+			}
+		}
+	}
+
+	/**
+	 * Magic mutator.
+	 *
+	 * @see \Mustache\HelperCollection::add
+	 *
+	 * @param string $name
+	 * @param mixed  $helper
+	 */
+	public function __set($name, $helper) {
+		$this->add($name, $helper);
+	}
+
+	/**
+	 * Add a helper to this collection.
+	 *
+	 * @param string $name
+	 * @param mixed  $helper
+	 */
+	public function add($name, $helper) {
+		$this->helpers[$name] = $helper;
+	}
+
+	/**
+	 * Magic accessor.
+	 *
+	 * @see \Mustache\HelperCollection::get
+	 *
+	 * @param string $name
+	 *
+	 * @return mixed Helper
+	 */
+	public function __get($name) {
+		return $this->get($name);
+	}
+
+	/**
+	 * Get a helper by name.
+	 *
+	 * @param string $name
+	 *
+	 * @return mixed Helper
+	 */
+	public function get($name) {
+		if (!$this->has($name)) {
+			throw new \InvalidArgumentException('Unknown helper: '.$name);
+		}
+
+		return $this->helpers[$name];
+	}
+
+	/**
+	 * Magic isset().
+	 *
+	 * @see \Mustache\HelperCollection::has
+	 *
+	 * @param string $name
+	 *
+	 * @return boolean True if helper is present
+	 */
+	public function __isset($name) {
+		return $this->has($name);
+	}
+
+	/**
+	 * Check whether a given helper is present in the collection.
+	 *
+	 * @param string $name
+	 *
+	 * @return boolean True if helper is present
+	 */
+	public function has($name) {
+		return array_key_exists($name, $this->helpers);
+	}
+
+	/**
+	 * Magic unset().
+	 *
+	 * @see \Mustache\HelperCollection::remove
+	 *
+	 * @param string $name
+	 */
+	public function __unset($name) {
+		$this->remove($name);
+	}
+
+	/**
+	 * Check whether a given helper is present in the collection.
+	 *
+	 * @throws \InvalidArgumentException if the requested helper is not present.
+	 *
+	 * @param string $name
+	 */
+	public function remove($name) {
+		if (!$this->has($name)) {
+			throw new \InvalidArgumentException('Unknown helper: '.$name);
+		}
+
+		unset($this->helpers[$name]);
+	}
+
+	/**
+	 * Clear the helper collection.
+	 *
+	 * Removes all helpers from this collection
+	 */
+	public function clear() {
+		$this->helpers = array();
+	}
+
+	/**
+	 * Check whether the helper collection is empty.
+	 *
+	 * @return boolean True if the collection is empty
+	 */
+	public function isEmpty() {
+		return empty($this->helpers);
+	}
+}

--- a/src/Mustache/Template.php
+++ b/src/Mustache/Template.php
@@ -57,7 +57,7 @@ abstract class Template {
 	 * @return string Rendered template
 	 */
 	public function render($context = array()) {
-		return $this->renderInternal(new Context($context));
+		return $this->renderInternal($this->prepareContextStack($context));
 	}
 
 	/**
@@ -119,4 +119,27 @@ abstract class Template {
 		}
 	}
 
+	/**
+	 * Helper method to prepare the Context stack.
+	 *
+	 * Adds the Mustache HelperCollection to the stack's top context frame if helpers are present.
+	 *
+	 * @param mixed $context Optional first context frame (default: null)
+	 *
+	 * @return \Mustache\Context
+	 */
+	protected function prepareContextStack($context = null) {
+		$stack = new Context;
+
+		$helpers = $this->mustache->getHelpers();
+		if (!$helpers->isEmpty()) {
+			$stack->push($helpers);
+		}
+
+		if (!empty($context)) {
+			$stack->push($context);
+		}
+
+		return $stack;
+	}
 }

--- a/test/Mustache/Test/HelperCollectionTest.php
+++ b/test/Mustache/Test/HelperCollectionTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of Mustache.php.
+ *
+ * (c) 2012 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mustache\Test;
+
+use Mustache\HelperCollection;
+
+class HelperCollectionTest extends \PHPUnit_Framework_TestCase {
+	public function testConstructor() {
+		$foo = function() { echo 'foo'; };
+		$bar = 'BAR';
+
+		$helpers = new HelperCollection(array(
+			'foo' => $foo,
+			'bar' => $bar,
+		));
+
+		$this->assertSame($foo, $helpers->get('foo'));
+		$this->assertSame($bar, $helpers->get('bar'));
+	}
+
+	public function testAccessorsAndMutators() {
+		$foo = function() { echo 'foo'; };
+		$bar = 'BAR';
+
+        $helpers = new HelperCollection;
+        $this->assertTrue($helpers->isEmpty());
+        $this->assertFalse($helpers->has('foo'));
+        $this->assertFalse($helpers->has('bar'));
+
+        $helpers->add('foo', $foo);
+        $this->assertFalse($helpers->isEmpty());
+        $this->assertTrue($helpers->has('foo'));
+        $this->assertFalse($helpers->has('bar'));
+
+        $helpers->add('bar', $bar);
+        $this->assertFalse($helpers->isEmpty());
+        $this->assertTrue($helpers->has('foo'));
+        $this->assertTrue($helpers->has('bar'));
+
+        $helpers->remove('foo');
+        $this->assertFalse($helpers->isEmpty());
+        $this->assertFalse($helpers->has('foo'));
+        $this->assertTrue($helpers->has('bar'));
+    }
+
+    public function testMagicMethods() {
+        $foo = function() { echo 'foo'; };
+        $bar = 'BAR';
+
+        $helpers = new HelperCollection;
+        $this->assertTrue($helpers->isEmpty());
+        $this->assertFalse($helpers->has('foo'));
+        $this->assertFalse($helpers->has('bar'));
+        $this->assertFalse(isset($helpers->foo));
+        $this->assertFalse(isset($helpers->bar));
+
+        $helpers->foo = $foo;
+        $this->assertFalse($helpers->isEmpty());
+        $this->assertTrue($helpers->has('foo'));
+        $this->assertFalse($helpers->has('bar'));
+        $this->assertTrue(isset($helpers->foo));
+        $this->assertFalse(isset($helpers->bar));
+
+        $helpers->bar = $bar;
+        $this->assertFalse($helpers->isEmpty());
+        $this->assertTrue($helpers->has('foo'));
+        $this->assertTrue($helpers->has('bar'));
+        $this->assertTrue(isset($helpers->foo));
+        $this->assertTrue(isset($helpers->bar));
+
+        unset($helpers->foo);
+        $this->assertFalse($helpers->isEmpty());
+        $this->assertFalse($helpers->has('foo'));
+        $this->assertTrue($helpers->has('bar'));
+        $this->assertFalse(isset($helpers->foo));
+        $this->assertTrue(isset($helpers->bar));
+    }
+
+    /**
+     * @dataProvider getInvalidHelperArguments
+     */
+    public function testHelperCollectionIsntAfraidToThrowExceptions($helpers = array(), $actions = array(), $exception = null) {
+        if ($exception) {
+            $this->setExpectedException($exception);
+        }
+
+        $helpers = new HelperCollection($helpers);
+
+        foreach ($actions as $method => $args) {
+            call_user_func_array(array($helpers, $method), $args);
+        }
+    }
+
+    public function getInvalidHelperArguments() {
+        return array(
+            array(
+                'not helpers',
+                array(),
+                '\InvalidArgumentException',
+            ),
+            array(
+                array(),
+                array('get' => array('foo')),
+                '\InvalidArgumentException',
+            ),
+            array(
+                array('foo' => 'FOO'),
+                array('get' => array('foo')),
+                null,
+            ),
+            array(
+                array('foo' => 'FOO'),
+                array('get' => array('bar')),
+                '\InvalidArgumentException',
+            ),
+            array(
+                array('foo' => 'FOO'),
+                array(
+                    'add' => array('bar', 'BAR'),
+                    'get' => array('bar'),
+                ),
+                null,
+            ),
+            array(
+                array('foo' => 'FOO'),
+                array(
+                    'get'    => array('foo'),
+                    'remove' => array('foo'),
+                ),
+                null,
+            ),
+            array(
+                array('foo' => 'FOO'),
+                array(
+                    'remove' => array('foo'),
+                    'get'    => array('foo'),
+                ),
+                '\InvalidArgumentException',
+            ),
+            array(
+                array(),
+                array('remove' => array('foo')),
+                '\InvalidArgumentException',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
In Mustache.php, "helpers" are implemented by injecting values into base of the context stack. This is very powerful, and also very simple. In my opinion, it's also spec compliant :)

Just like other values in the rendering context, helpers can be "lambdas" (suitable for services) or regular values (which are more akin to constants or global variables in PHP).

For example, if you want to add an i18n translation service to Mustache, you'd do something like this:

``` php
<?php

$m = new Mustache;
$m->addHelper('_i18n', function($text) {
    // IRL, you would use something far more robust :)
    $dictionary = array(
        'Hello.' => 'Hola.',
        'My name is {{ name }}.' => 'Me llamo {{ name }}.',
    );

    return array_key_exists($text, $dictionary) ? $dictionary[$text] : $text;
});

$tpl = $m->loadTemplate('{{#_i18n}}Hello.{{/_i18n}} {{#_i18n}}My name is {{ name }}.{{/_i18n}}');
$tpl->render(array('name' => 'Justin'));
```

And this would render:

```
Hola. Me llamo Justin.
```

... Pretty rad, eh?

This is implemented as a "frame 0" on the context stack. This means all data passed in to `render()` will end up in "frame 1", and will be able to mask helpers. Using the example above, if we passed in a _new_ lambda as `_i18n`, the call to `{{#_i18n}}` would resolve to the new value rather than the helper. This is consistent with how the context stack works elsewhere in Mustache.
