### PR TITLE
Changing private to protected

### DIFF
--- a/src/Mustache/Loader/FilesystemLoader.php
+++ b/src/Mustache/Loader/FilesystemLoader.php
@@ -88,7 +88,7 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
      *
      * @return string Mustache Template source
      */
-    private function loadFile($name)
+    protected function loadFile($name)
     {
         $fileName = $this->getFileName($name);
 
@@ -106,7 +106,7 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
      *
      * @return string Template file name
      */
-    private function getFileName($name)
+    protected function getFileName($name)
     {
         $fileName = $this->baseDir . '/' . $name;
         if (substr($fileName, 0 - strlen($this->extension)) !== $this->extension) {


### PR DESCRIPTION
These fixes came out of this issue (https://github.com/ppi/framework/issues/51).

Changing private to protected to that getFileName() can be overridden to use symfony-based templating locators.
