### PR TITLE
Option to set cache file permissions and cache directory permission fix.

### DIFF
--- a/src/Mustache/Engine.php
+++ b/src/Mustache/Engine.php
@@ -581,6 +581,7 @@ class Mustache_Engine
     {
         if (!is_dir(dirname($fileName))) {
             mkdir(dirname($fileName), 0777, true);
+            chmod(dirname($fileName), 0777); // mkdir can have been affected by current umask
         }
 
         $tempFile = tempnam(dirname($fileName), basename($fileName));


### PR DESCRIPTION
Added option to set cache file permissions (like you can do with Zend_Cache_Backend_File). It's needed in some setups like ours.  

The cache directory wasn't created with the set permissions under some conditions (probably an umask related issue), so added a fix for that as well.
