### PR TITLE
Bind section lambdas?

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,10 +3,15 @@
 	<testsuite name="Mustache">
 		<directory suffix="Test.php">./test</directory>
 		<exclude>./test/Mustache/Test/FiveThree</exclude>
+		<exclude>./test/Mustache/Test/FiveFour</exclude>
 	</testsuite>
 
 	<testsuite name="Mustache FiveThree">
 		<directory suffix="Test.php" phpVersion="5.3.0" phpVersionOperator=">=">./test/Mustache/Test/FiveThree</directory>
+	</testsuite>
+
+	<testsuite name="Mustache FiveFour">
+		<directory suffix="Test.php" phpVersion="5.4.0" phpVersionOperator=">=">./test/Mustache/Test/FiveFour</directory>
 	</testsuite>
 
 	<filter>

--- a/src/Mustache/Engine.php
+++ b/src/Mustache/Engine.php
@@ -39,6 +39,7 @@ class Mustache_Engine
     private $helpers;
     private $escape;
     private $charset = 'UTF-8';
+    private $bindLambdas;
 
     /**
      * Mustache class constructor.
@@ -117,6 +118,8 @@ class Mustache_Engine
         if (isset($options['charset'])) {
             $this->charset = $options['charset'];
         }
+
+        $this->bindLambdas = version_compare(PHP_VERSION, '5.4.0', '>=');
     }
 
     /**
@@ -409,10 +412,11 @@ class Mustache_Engine
     public function getTemplateClassName($source)
     {
         return $this->templateClassPrefix . md5(sprintf(
-            'version:%s,escape:%s,charset:%s,source:%s',
+            'version:%s,escape:%s,charset:%s,bind:%s,source:%s',
             self::VERSION,
             isset($this->escape) ? 'custom' : 'default',
             $this->charset,
+            $this->bindLambdas ? 'true' : 'false',
             $source
         ));
     }
@@ -544,7 +548,7 @@ class Mustache_Engine
         $tree = $this->parse($source);
         $name = $this->getTemplateClassName($source);
 
-        return $this->getCompiler()->compile($source, $tree, $name, isset($this->escape), $this->charset);
+        return $this->getCompiler()->compile($source, $tree, $name, isset($this->escape), $this->charset, $this->bindLambdas);
     }
 
     /**

--- a/test/Mustache/Test/FiveFour/Functional/LambdaHelperTest.php
+++ b/test/Mustache/Test/FiveFour/Functional/LambdaHelperTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Mustache.php.
+ *
+ * (c) 2012 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @group lambdas
+ * @group functional
+ */
+class Mustache_Test_FiveFour_Functional_LambdaHelperTest extends PHPUnit_Framework_TestCase
+{
+    private $mustache;
+
+    public function setUp()
+    {
+        $this->mustache = new Mustache_Engine;
+    }
+
+    public function testSectionLambdasAreBoundToLambdaHelper()
+    {
+        $one = $this->mustache->loadTemplate('{{name}}');
+        $two = $this->mustache->loadTemplate('{{#lambda}}{{name}}{{/lambda}}');
+
+        $foo = new StdClass;
+        $foo->name = 'Mario';
+        $foo->lambda = function($text) {
+            return strtoupper($this->render($text));
+        };
+
+        $this->assertEquals('Mario', $one->render($foo));
+        $this->assertEquals('MARIO', $two->render($foo));
+    }
+}


### PR DESCRIPTION
In PHP 5.4, we can re-bind Closures, essentially giving them a new `$this` internally. This change does that for higher order sections (section lambdas). Which means we can use this:

``` php
<?php
$data = array(
  'foo' => 'win',
  'embiggen' => function($text) {
    return strtoupper($this->render($text));
  },
);
```

instead of this:

``` php
<?php
$data = array(
  'foo' => 'win',
  'embiggen' => function($text, $mustache) {
    return strtoupper($mustache->render($text));
  },
);
```

My question is: is this a good thing? Should it be optional? Should it even be offered?

Pros:
- It saves a bit of typing.
- `$this->render` seems like a natural fit if you think of the Closure as the context of the section.
- `$this` could potentially expose other things to the section lambda in the future, such as the current indent level of the template.

Cons:
- (if always-enabled) it prevents more advanced Closure usage, for example, having a ViewModel object bind the closures it returns to itself, giving them access to private or protected members.
- (if configurable) it presents an interesting — and possibly hard to track down — situation when the engine instantiation changes. Trying to figure out why `$this` isn't what you expect it to be is sometimes really confusing, c.f. JavaScript :)
- (if configurable) it is yet another configuration option, but one that's only available for some versions of PHP.
- Other future things (indent level, etc) could also be exposed via the `$mustache` argument passed to the Closure.

Neutral:
- Because it's compiled-in, it doesn't have a measurable effect on performance either way.
- This shortcut is not available for non-Closure callables, e.g. the `array($this, 'doFoo')` style callables.

See #101

Please discuss.
