### PR TITLE
Add "anchored dot notation"

### DIFF
--- a/src/Mustache/Context.php
+++ b/src/Mustache/Context.php
@@ -128,7 +128,12 @@ class Mustache_Context
     {
         $chunks = explode('.', $id);
         $first  = array_shift($chunks);
-        $value  = $this->findVariableInStack($first, $this->stack);
+
+        if ($first === '') {
+            $value = $this->last();
+        } else {
+            $value = $this->findVariableInStack($first, $this->stack);
+        }
 
         foreach ($chunks as $chunk) {
             if ($value === '') {

--- a/test/Mustache/Test/ContextTest.php
+++ b/test/Mustache/Test/ContextTest.php
@@ -119,6 +119,49 @@ class Mustache_Test_ContextTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('win', $context->find('baz'), 'ArrayAccess stands alone');
         $this->assertEquals('win', $context->find('qux'), 'ArrayAccess beats private property');
     }
+
+    public function testAnchoredDotNotation()
+    {
+        $context = new Mustache_Context();
+
+        $a = array(
+            'name'   => 'a',
+            'number' => 1,
+        );
+
+        $b = array(
+            'number' => 2,
+            'child'  => array(
+                'name' => 'baby bee',
+            ),
+        );
+
+        $c = array(
+            'name' => 'cee',
+        );
+
+        $context->push($a);
+        $this->assertEquals('a', $context->find('name'));
+        $this->assertEquals('a', $context->findDot('.name'));
+        $this->assertEquals(1, $context->find('number'));
+        $this->assertEquals(1, $context->findDot('.number'));
+
+        $context->push($b);
+        $this->assertEquals('a', $context->find('name'));
+        $this->assertEquals(2, $context->find('number'));
+        $this->assertEquals('', $context->findDot('.name'));
+        $this->assertEquals(2, $context->findDot('.number'));
+        $this->assertEquals('baby bee', $context->findDot('child.name'));
+        $this->assertEquals('baby bee', $context->findDot('.child.name'));
+
+        $context->push($c);
+        $this->assertEquals('cee', $context->find('name'));
+        $this->assertEquals('cee', $context->findDot('.name'));
+        $this->assertEquals(2, $context->find('number'));
+        $this->assertEquals('', $context->findDot('.number'));
+        $this->assertEquals('baby bee', $context->findDot('child.name'));
+        $this->assertEquals('', $context->findDot('.child.name'));
+    }
 }
 
 class Mustache_Test_TestDummy


### PR DESCRIPTION
 1. Given that `{{ . }}` resolves as the top of the context stack;
 2. And when any falsey segment in a dotted name is encountered, the whole name yields `''`;
 3. A name like `{{ .name }}` should imply `{{ [top of stack].name }}`;
 4. Thus, it must resolve as truthy _only_ if a member of the top of the context stack matches `name`.

There have been several syntaxes proposed (mustache/spec#10 and mustache/spec#11 as well as my mustache/spec#52). This one is my favorite because,

 * It introduces no new symbols, it simply allows combining two existing syntaxes into a single tag.
 * It is backwards compatible, meaning, no currently working code will be broken, since `{{ .foo.bar }}` isn't a valid variable name in the current spec.
 * It doesn't come with any of the crazy traversal logic that the `{{ ../foo }}` style anchors do, so I feel it's more in keeping with the logic-free nature of Mustache.
 * It doesn't involve blessing any valid variable names as super-variables (e.g. the proposed `{{ this.foo }}` syntax, which would be a backwards compatibility break, as well as limiting perfectly valid variable names in some languages.

See spec discussion at mustache/spec#52 and some impetus at #98.

This is a complete implementation, but it's currently missing tests. I'm torn on including it without a pragma, since it would technically make Mustache.php not spec compliant.

Thoughts?