### PR TITLE
Implement template inheritance via `{{% BLOCKS }}` pragma.

### DIFF
--- a/src/Mustache/Parser.php
+++ b/src/Mustache/Parser.php
@@ -63,6 +63,17 @@ class Mustache_Parser
                     $this->clearStandaloneLines($nodes, $tokens);
                     break;
 
+                case Mustache_Tokenizer::T_BLOCK:
+                    if (isset($this->pragmas[Mustache_Engine::PRAGMA_BLOCKS])) {
+                        $this->clearStandaloneLines($nodes, $tokens);
+                        $nodes[] = $this->buildTree($tokens, $token);
+                    } else {
+                        $token[Mustache_Tokenizer::TYPE] = Mustache_Tokenizer::T_ESCAPED;
+                        $token[Mustache_Tokenizer::NAME] = '$'.$token[Mustache_Tokenizer::NAME];
+                        $nodes[] = $token;
+                    }
+                    break;
+
                 case Mustache_Tokenizer::T_SECTION:
                 case Mustache_Tokenizer::T_INVERTED:
                     $this->clearStandaloneLines($nodes, $tokens);

--- a/src/Mustache/Template.php
+++ b/src/Mustache/Template.php
@@ -79,7 +79,7 @@ abstract class Mustache_Template
      *
      * @return string Rendered template
      */
-    abstract public function renderInternal(Mustache_Context $context, $indent = '');
+    abstract public function renderInternal(Mustache_Context $context, $indent = '', $escape = false);
 
     /**
      * Tests whether a value should be iterated over (e.g. in a section context).

--- a/src/Mustache/Tokenizer.php
+++ b/src/Mustache/Tokenizer.php
@@ -35,6 +35,7 @@ class Mustache_Tokenizer
     const T_UNESCAPED_2  = '&';
     const T_TEXT         = '_t';
     const T_PRAGMA       = '%';
+    const T_BLOCK        = '$';
 
     // Valid token types
     private static $tagTypes = array(
@@ -49,6 +50,7 @@ class Mustache_Tokenizer
         self::T_UNESCAPED    => true,
         self::T_UNESCAPED_2  => true,
         self::T_PRAGMA       => true,
+        self::T_BLOCK        => true,
     );
 
     // Interpolated tags
@@ -260,6 +262,27 @@ class Mustache_Tokenizer
         ));
 
         return $end + strlen($this->ctag) - 1;
+    }
+
+    private function getPragma($text)
+    {
+        $chunks = explode(' ', trim($text));
+        $pragma = array(
+            self::TYPE  => self::T_PRAGMA,
+            self::NAME  => array_shift($chunks),
+            self::VALUE => array(),
+        );
+
+        foreach ($chunks as $chunk) {
+            list($key, $val) = explode('=', $chunk, 2);
+            $pragma[self::VALUE][$key] = $val;
+        }
+
+        if (empty($pragma[self::VALUE])) {
+            unset($pragma[self::VALUE]);
+        }
+
+        return $pragma;
     }
 
     /**


### PR DESCRIPTION
This is a proof-of-concept implementation of template inheritance via blocks.

Say we have a template named `layout.mustache`. This would be our generic site layout template, consisting of all the sorts of things you'd expect in a layout template. In addition, it would have a number of blocks defined. The blocks look like Mustache sections, but they're denoted with `{{$ block }}` tags instead of `#`.

``` html+jinja
<!-- layout.mustache -->
{{% BLOCKS }}
<!DOCTYPE html>
<html>
  <head>
    <title>{{$ title }}My Alsome Site{{/ title }}</title>
    {{$ stylesheets }}
      <link rel="stylesheet" href="/assets/css/default.css">
    {{/ stylesheets }}
  </head>
  <body>
    <header>
      {{$ header }}
        <h1>Welcome to My Alsome Site</h1>
      {{/ header }}
    </header>
    <section id="content">
      {{$ content }}
        <p>Hello, World!</p>
      {{/ content }}
    </section>
    {{$ scripts }}
      <script src="/assets/js/default.js"></script>
    {{/ scripts }}
  </body>
</html>
```

The blocks defined here are `{{$ title }}`, `{{$ stylesheets }}`, `{{$ header }}`, `{{$ content }}` and `{{$ scripts }}`.

By default, blocks merely delineate sections of the template which _can_ be extended (replaced) in subtemplates. If the parent template itself is rendered, the block tags are simply rendered as if they are truthy sections.

This `layout` template can then be extended by other sub-templates, which declare their intention by adding a `parent=layout` to the `{{% BLOCKS }}` pragma tag: 

``` html+jinja
<!-- page.mustache -->
{{% BLOCKS parent=layout}}

{{$ title }}My Alsome Page{{/ title }}

{{$ stylesheets }}
  <link rel="stylesheet" href="/assets/css/page.css">
{{/ stylesheets }}

{{$ header }}
  <h1>My page has some items!</h1>
{{/ header }}

{{$ content }}
  <ul>
    {{# items }}
      <li><a href="{{ link }}" title="{{ name }}">{{ name }}</a></li>
    {{/ items }}
  </ul>
{{/ content }}
```

Upon rendering this `page.mustache`, the subtemplate blocks will be substituted for the parent blocks, resulting in (approximately) this:

``` html+jinja
<!DOCTYPE html>
<html>
  <head>
    <title>My Alsome Page</title>
    <link rel="stylesheet" href="/assets/css/page.css">
  </head>
  <body>
    <header>
      <h1>My page has some items!</h1>
    </header>
    <section id="content">
      <ul>
        {{# items }}
          <li><a href="{{ link }}" title="{{ name }}">{{ name }}</a></li>
        {{/ items }}
      </ul>
    </section>
    <script src="/assets/js/default.js"></script>
  </body>
</html>
```

In our example, we didn't override every block: the `{{$ scripts }}` block retained its default value. We could also create a new subtemplate which extends `page.mustache`, say `custom-page.mustache`. That subtemplate might only replace the `{{$ content }}` block of `page.mustache`, and inherit the rest.

Note that `page.mustache` could even define new blocks. Maybe add a `{{$ main }}` and `{{$ complimentary }}` section inside `{{$ content }}`:

``` html+jinja
{{$ content }}
  <div id="main" role="main">
    {{$ main }}{{/ main }}
  </div>
  <div id="complimentary" role="complimentary">
    {{$ complimentary }}{{/ complimentary }}
  </div>
{{/ content }}
```

Then sub-subtemplates could choose to override just the `{{$ main }}` block, while leaving `{{$ content }}` and `{{$ complimentary }}` intact.
