### PR TITLE
Make 'context' public in lambda helper

### DIFF
--- a/src/Mustache/LambdaHelper.php
+++ b/src/Mustache/LambdaHelper.php
@@ -18,7 +18,7 @@
 class Mustache_LambdaHelper
 {
     private $mustache;
-    private $context;
+    public $context;
 
     /**
      * Mustache Lambda Helper constructor.


### PR DESCRIPTION
there are cases when it is helpful to be able to add to the context stack from a lambda callback. To do that, the 'context' needs to be public. 
