### PR TITLE
Allow calling ->render() without a context

### DIFF
--- a/src/Mustache/Engine.php
+++ b/src/Mustache/Engine.php
@@ -165,7 +165,7 @@ class Mustache_Engine
      *
      * @return string Rendered template
      */
-    public function render($template, $data)
+    public function render($template, $data = array())
     {
         return $this->loadTemplate($template)->render($data);
     }


### PR DESCRIPTION
Calling render() in the engine on a template currently requires you pass at least an empty array for context, though the underlying template class that gets proxied into has a default value of array(), so it doesn't seem to be strictly required. This changes simply allows array() to be passed down instead of requiring the user pass it manually. 
