### PR TITLE
$mustache should be public

### DIFF
--- a/src/Mustache/LambdaHelper.php
+++ b/src/Mustache/LambdaHelper.php
@@ -18,7 +18,7 @@
  */
 class Mustache_LambdaHelper
 {
-    private $mustache;
+    public $mustache;
     private $context;
 
     /**


### PR DESCRIPTION
be cause of this code works : 
(for zf2 view helper usage)
public function addBasePath(MvcEvent $e) {
        $viewModel = $e->getViewModel();
        $variables = $viewModel->getVariables();
        $mustacheEngine = $e->getApplication()->getServiceManager()->get('mustacheviewrenderer')->getEngine();
        $basePathHelper =  $e->getApplication()->getServiceManager()->get('viewhelpermanager')->get('basepath');
        $mustacheEngine->zendHelpers['basepath'] = $basePathHelper;
        $mustacheEngine->addHelper('basePath', function($text,$mustache) {
            // global $basePathHelper;
            $basepathhelper = $mustache->mustache->zendHelpers['basepath'];
            return $basepathhelper->__invoke($text);
        });

```
}
```
