### PR TITLE
Allow paths to include protocols prepended to the path.

### DIFF
--- a/src/Mustache/Loader/FilesystemLoader.php
+++ b/src/Mustache/Loader/FilesystemLoader.php
@@ -49,7 +49,7 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
     {
         $this->baseDir = $baseDir;
 
-        if ( strpos( $this->baseDir, '://' ) === -1 ) {
+        if (strpos( $this->baseDir, '://' ) === -1) {
             $this->baseDir = rtrim(realpath($this->baseDir), '/');
         }
 


### PR DESCRIPTION
This would allow vfsStream to be used as a mock filesystem when writing unit tests, as well as some other cool things.
