### PR TITLE
Performance tweaks

### DIFF
--- a/src/Mustache/Context.php
+++ b/src/Mustache/Context.php
@@ -139,7 +139,7 @@ class Mustache_Context
                 } elseif (isset($stack[$i]->$id)) {
                     return $stack[$i]->$id;
                 }
-            } elseif (is_array($stack[$i]) && array_key_exists($id, $stack[$i])) {
+            } elseif (is_array($stack[$i]) && isset($stack[$i][$id])) {
                 return $stack[$i][$id];
             }
         }

--- a/src/Mustache/Logger/StreamLogger.php
+++ b/src/Mustache/Logger/StreamLogger.php
@@ -70,7 +70,7 @@ class Mustache_Logger_StreamLogger extends Mustache_Logger_AbstractLogger
      */
     public function setLevel($level)
     {
-        if (!array_key_exists($level, self::$levels)) {
+        if (!isset(self::$levels[$level])) {
             throw new Mustache_Exception_InvalidArgumentException(sprintf('Unexpected logging level: %s', $level));
         }
 
@@ -98,7 +98,7 @@ class Mustache_Logger_StreamLogger extends Mustache_Logger_AbstractLogger
      */
     public function log($level, $message, array $context = array())
     {
-        if (!array_key_exists($level, self::$levels)) {
+        if (!isset(self::$levels[$level])) {
             throw new Mustache_Exception_InvalidArgumentException(sprintf('Unexpected logging level: %s', $level));
         }
 


### PR DESCRIPTION
While integrating Mustache templates into an existing system, I found a couple of micro-optimizations in this library that could, under some circumstances, drastically increase rendering performance.  Switching `array_key_exists()` calls to their `isset()` equivalents has a simple-case speedup of about 30%.  For large templates with deep contexts, this can result in considerable, measurable time savings.
