### PR TITLE
Add ability to render helpers with arbitrary data.

### DIFF
--- a/src/Mustache/LambdaHelper.php
+++ b/src/Mustache/LambdaHelper.php
@@ -40,10 +40,13 @@ class Mustache_LambdaHelper
      *
      * @return Rendered template.
      */
-    public function render($string)
+    public function render($string, $context = NULL)
     {
-        return $this->mustache
-            ->loadLambda((string) $string)
-            ->renderInternal($this->context);
+        if ($context === NULL)
+            return $this->mustache
+                ->loadLambda((string) $string)
+                ->renderInternal($this->context);
+
+        return $this->mustache->render($string, $context);
     }
 }

--- a/test/Mustache/Test/Functional/LambdaTest.php
+++ b/test/Mustache/Test/Functional/LambdaTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Mustache.php.
+ *
+ * (c) 2013 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @group functional
+ */
+class Mustache_Test_Functional_LambdaTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testLambda()
+    {
+        $m = new Mustache_Engine;
+        $tpl = $m->loadTemplate('{{#people}}{{name}} {{/people}}');
+
+        $data = array('people' => function($text, Mustache_LambdaHelper $helper) {
+            $people = array(
+                array('name' => 'Alice'),
+                array('name' => 'Bob'),
+                array('name' => 'Charlie'),
+            );
+
+            $str = '';
+            foreach ($people as $person)
+                $str .= $helper->render($text, $person);
+            return $str;
+        });
+
+        $this->assertEquals('Alice Bob Charlie ', $tpl->render($data));
+    }
+}


### PR DESCRIPTION
I'm trying to render the contents of a loop based on values from a database, but using a lambda so that I can do it lazily (ie not call the database unless the template contains certain tags).

Just picture that the line:

    $people = array(

is actually a database call.

Feel free to push back if you feel like there's a better way to do this, but I've been running this change in production for a while and it works well.

Thanks!