### PR TITLE
Uneven braces in triples are incorrectly swallowing a character [repost of 208]

### DIFF
--- a/src/Mustache/Tokenizer.php
+++ b/src/Mustache/Tokenizer.php
@@ -179,6 +179,14 @@ class Mustache_Tokenizer
                                 $lastName = $token[self::NAME];
                                 if (substr($lastName, -1) === '}') {
                                     $token[self::NAME] = trim(substr($lastName, 0, -1));
+                                } else {
+                                    $msg = sprintf(
+                                        'Uneven closing tag encountered: %s on line %d',
+                                        substr($lastName, -1),
+                                        $token[self::LINE]
+                                    );
+
+                                    throw new Mustache_Exception_SyntaxException($msg, $token);
                                 }
                             }
                         }

--- a/test/Mustache/Test/TokenizerTest.php
+++ b/test/Mustache/Test/TokenizerTest.php
@@ -35,6 +35,17 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
         $tokenizer->scan($text, null);
     }
 
+    /**
+     * @expectedException Mustache_Exception_SyntaxException
+     */
+    public function testUnevenBracesWithCustomDelimiterThrowExceptions()
+    {
+        $tokenizer = new Mustache_Tokenizer;
+
+        $text = "<%{ name %>";
+        $tokenizer->scan($text, "<% %>");
+    }
+
     public function getTokens()
     {
         return array(
@@ -244,6 +255,22 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::LINE  => 0,
                         Mustache_Tokenizer::VALUE => "}}}",
                     ),
+                )
+            ),
+
+            // unescaped custom delimiters are properly parsed
+            array(
+                "<%{ a }%>",
+                "<% %>",
+                array(
+                    array(
+                        Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_UNESCAPED,
+                        Mustache_Tokenizer::NAME  => 'a',
+                        Mustache_Tokenizer::OTAG  => '<%',
+                        Mustache_Tokenizer::CTAG  => '%>',
+                        Mustache_Tokenizer::LINE  => 0,
+                        Mustache_Tokenizer::INDEX => 9,
+                    )
                 )
             ),
         );


### PR DESCRIPTION
This is the same as https://github.com/bobthecow/mustache.php/pull/208 but only includes the relevant files.

I found this issue the other day where triple tags that are incorrectly formatted are being used as if they were properly formatted. I'm not sure if this is the correct and expected behavior, but what is certainly not right in this case, is that they are incorrectly swallowing the next character. This gist should demonstrate the issue.

https://gist.github.com/smarden1/470f67980f006832a667

Without looking at that gist, the issue is that the template &#60;h1>{{{ text }}&#60;/h1> is not properly closed. Unfortunately, what happens here is that the next character is swallowed and disappears, making the result be &#60;h1>some_text/h1>, which is not proper html.

For this pull request, I had the tokenizer throw a SynaxException as it is unclear what should happen in this case.

I looked into other implementations of mustache and they are treating this in different ways. I believe the ruby one throws and error and the js one continues along until it finds the appropriate closing triple.
