### PR TITLE
Extendability

### DIFF
--- a/src/Mustache/Compiler.php
+++ b/src/Mustache/Compiler.php
@@ -24,6 +24,7 @@ class Mustache_Compiler
     private $charset;
     private $strictCallables;
     private $pragmas;
+    protected $templateBaseClass = "Mustache_Template";
 
     /**
      * Compile a Mustache token parse tree into PHP source code.
@@ -127,7 +128,7 @@ class Mustache_Compiler
 
     const KLASS = '<?php
 
-        class %s extends Mustache_Template
+        class %s extends %s
         {
             protected $templateFileName = "%s";
             private $lambdaHelper;%s
@@ -150,7 +151,7 @@ class Mustache_Compiler
 
     const KLASS_NO_LAMBDAS = '<?php
 
-        class %s extends Mustache_Template
+        class %s extends %s
         {
             protected $templateFileName = "%s";
         %s
@@ -186,7 +187,7 @@ class Mustache_Compiler
         $klass    = empty($this->sections) ? self::KLASS_NO_LAMBDAS : self::KLASS;
         $callable = $this->strictCallables ? $this->prepare(self::STRICT_CALLABLE) : '';
 
-        return sprintf($this->prepare($klass, 0, false, true), $name, $templateName, $callable, $code, $sections);
+        return sprintf($this->prepare($klass, 0, false, true), $name, $this->templateBaseClass, $templateName, $callable, $code, $sections);
     }
 
     const SECTION_CALL = '

--- a/src/Mustache/Engine.php
+++ b/src/Mustache/Engine.php
@@ -582,7 +582,7 @@ class Mustache_Engine
      */
     public function loadTemplate($name)
     {
-        return $this->loadSource($this->getLoader()->load($name));
+        return $this->loadSource($name, $this->getLoader()->load($name));
     }
 
     /**
@@ -606,7 +606,7 @@ class Mustache_Engine
                 throw new Mustache_Exception_UnknownTemplateException($name);
             }
 
-            return $this->loadSource($loader->load($name));
+            return $this->loadSource($name, $loader->load($name));
         } catch (Mustache_Exception_UnknownTemplateException $e) {
             // If the named partial cannot be found, log then return null.
             $this->log(
@@ -652,7 +652,7 @@ class Mustache_Engine
      *
      * @return Mustache_Template
      */
-    private function loadSource($source, Mustache_Cache $cache = null)
+    private function loadSource($templateName, $source, Mustache_Cache $cache = null)
     {
         $className = $this->getTemplateClassName($source);
 
@@ -663,7 +663,7 @@ class Mustache_Engine
 
             if (!class_exists($className, false)) {
                 if (!$cache->load($className)) {
-                    $compiled = $this->compile($source);
+                    $compiled = $this->compile($templateName, $source);
                     $cache->cache($className, $compiled);
                 }
             }
@@ -717,7 +717,7 @@ class Mustache_Engine
      *
      * @return string generated Mustache template class code
      */
-    private function compile($source)
+    private function compile($templateName, $source)
     {
         $tree = $this->parse($source);
         $name = $this->getTemplateClassName($source);
@@ -728,7 +728,7 @@ class Mustache_Engine
             array('className' => $name)
         );
 
-        return $this->getCompiler()->compile($source, $tree, $name, isset($this->escape), $this->charset, $this->strictCallables, $this->entityFlags);
+        return $this->getCompiler()->compile($templateName, $source, $tree, $name, isset($this->escape), $this->charset, $this->strictCallables, $this->entityFlags);
     }
 
     /**

--- a/src/Mustache/Template.php
+++ b/src/Mustache/Template.php
@@ -27,6 +27,11 @@ abstract class Mustache_Template
     protected $strictCallables = false;
 
     /**
+     * @var string
+     */
+    protected $templateFileName;
+
+    /**
      * Mustache Template constructor.
      *
      * @param Mustache_Engine $mustache
@@ -34,6 +39,17 @@ abstract class Mustache_Template
     public function __construct(Mustache_Engine $mustache)
     {
         $this->mustache = $mustache;
+    }
+
+    protected function beforeRender(Mustache_Context $context)
+    {
+        //here you can write logic for caching depend of $this->templateFileName
+        return false;
+    }
+
+    protected function afterRender(Mustache_Context $context, &$buffer)
+    {
+        return false;
     }
 
     /**


### PR DESCRIPTION
- possible to extend `Mustache_Template` class
- original template name available in compiled template instance 
- added `beforeRender,afterRender` methods, they can be used for caching 