### PR TITLE
sequential array checking speedup

### DIFF
--- a/src/Mustache/Template.php
+++ b/src/Mustache/Template.php
@@ -107,21 +107,15 @@ abstract class Mustache_Template
      *
      * @param mixed $value
      *
-     * @return boolean True if the value is 'iterable'
+ * @return boolean True if the value is 'iterable'
      */
     protected function isIterable($value)
     {
         if (is_object($value)) {
             return $value instanceof Traversable;
         } elseif (is_array($value)) {
-            $i = 0;
-            foreach ($value as $k => $v) {
-                if ($k !== $i++) {
-                    return false;
-                }
-            }
-
-            return true;
+            //is sequential array - not associative
+            return array_keys($value) === range(0, count($value) - 1);
         } else {
             return false;
         }


### PR DESCRIPTION
This variant almost 2 times faster
Test:

```
for ($j = 1; $j < 7; $j++) {
    $value = range(0, pow(10, $j));
    $a = -microtime(true);
    //is sequential array - not associative
    array_keys($value) === range(0, count($value) - 1);
    $a += microtime(true);
    echo $a;
    echo " ";
    $a = -microtime(true);
    $i = 0;
    foreach ($value as $k => $v) {
        if ($k !== $i++) {
            return false;
        }
    }
    $a += microtime(true);
    echo $a;
    echo "\n";
}
```

Result:

1.0013580322266E-5 5.9604644775391E-6
3.504753112793E-5 3.2901763916016E-5
0.0005040168762207 0.00033116340637207
0.0060639381408691 0.0033388137817383
0.070620775222778 0.026356935501099
0.62192797660828 0.29023885726929
