### PR TITLE
Fix multiline array CS

### DIFF
--- a/src/Mustache/Tokenizer.php
+++ b/src/Mustache/Tokenizer.php
@@ -155,7 +155,7 @@ class Mustache_Tokenizer
                             self::OTAG  => $this->otag,
                             self::CTAG  => $this->ctag,
                             self::LINE  => $this->line,
-                            self::INDEX => ($this->tagType === self::T_END_SECTION) ? $this->seenTag - $this->otagLen : $i + $this->ctagLen
+                            self::INDEX => ($this->tagType === self::T_END_SECTION) ? $this->seenTag - $this->otagLen : $i + $this->ctagLen,
                         );
 
                         if ($this->tagType === self::T_UNESCAPED) {
@@ -235,7 +235,7 @@ class Mustache_Tokenizer
             $this->tokens[] = array(
                 self::TYPE  => self::T_TEXT,
                 self::LINE  => $this->line,
-                self::VALUE => $this->buffer
+                self::VALUE => $this->buffer,
             );
             $this->buffer   = '';
         }

--- a/test/Mustache/Test/CompilerTest.php
+++ b/test/Mustache/Test/CompilerTest.php
@@ -47,7 +47,7 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_ESCAPED,
                         Mustache_Tokenizer::NAME => 'name',
-                    )
+                    ),
                 ),
                 'Monkey',
                 true,
@@ -58,7 +58,7 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
                     '$value = $this->resolveValue($context->find(\'name\'), $context, $indent);',
                     '$buffer .= $indent . call_user_func($this->mustache->getEscape(), $value);',
                     'return $buffer;',
-                )
+                ),
             ),
 
             array(
@@ -67,7 +67,7 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_ESCAPED,
                         Mustache_Tokenizer::NAME => 'name',
-                    )
+                    ),
                 ),
                 'Monkey',
                 false,
@@ -78,7 +78,7 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
                     '$value = $this->resolveValue($context->find(\'name\'), $context, $indent);',
                     '$buffer .= $indent . htmlspecialchars($value, ' . ENT_COMPAT . ', \'ISO-8859-1\');',
                     'return $buffer;',
-                )
+                ),
             ),
 
             array(
@@ -87,7 +87,7 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_ESCAPED,
                         Mustache_Tokenizer::NAME => 'name',
-                    )
+                    ),
                 ),
                 'Monkey',
                 false,
@@ -98,7 +98,7 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
                     '$value = $this->resolveValue($context->find(\'name\'), $context, $indent);',
                     '$buffer .= $indent . htmlspecialchars($value, ' . ENT_QUOTES . ', \'ISO-8859-1\');',
                     'return $buffer;',
-                )
+                ),
             ),
 
             array(
@@ -127,7 +127,7 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
                     '$value = $this->resolveValue($context->last(), $context, $indent);',
                     '$buffer .= \'\\\'bar\\\'\';',
                     'return $buffer;',
-                )
+                ),
             ),
         );
     }

--- a/test/Mustache/Test/ContextTest.php
+++ b/test/Mustache/Test/ContextTest.php
@@ -22,7 +22,7 @@ class Mustache_Test_ContextTest extends PHPUnit_Framework_TestCase
 
         $two = new Mustache_Context(array(
             'foo' => 'FOO',
-            'bar' => '<BAR>'
+            'bar' => '<BAR>',
         ));
         $this->assertEquals('FOO', $two->find('foo'));
         $this->assertEquals('<BAR>', $two->find('bar'));

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -151,7 +151,7 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
     public function testWithoutLambdaCache()
     {
         $mustache = new MustacheStub(array(
-            'cache' => self::$tempDir
+            'cache' => self::$tempDir,
         ));
 
         $this->assertInstanceOf('Mustache_Cache_NoopCache', $mustache->getProtectedLambdaCache());
@@ -193,7 +193,7 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
             'partials_loader' => new Mustache_Loader_ArrayLoader(array(
                 'foo' => 'FOO',
                 'baz' => 'BAZ',
-            ))
+            )),
         ));
 
         $this->assertEquals('FOOBAZ', $mustache->render('{{>foo}}{{>bar}}{{>baz}}', array()));
@@ -327,7 +327,7 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
     public function testUnknownPragmaThrowsException()
     {
         new Mustache_Engine(array(
-            'pragmas' => array('UNKNOWN')
+            'pragmas' => array('UNKNOWN'),
         ));
     }
 
@@ -335,7 +335,7 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
     {
         $name     = tempnam(sys_get_temp_dir(), 'mustache-test');
         $mustache = new Mustache_Engine(array(
-            'logger' => new Mustache_Logger_StreamLogger($name, $level)
+            'logger' => new Mustache_Logger_StreamLogger($name, $level),
         ));
 
         return array($name, $mustache);

--- a/test/Mustache/Test/FiveThree/Functional/EngineTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/EngineTest.php
@@ -33,7 +33,7 @@ class Mustache_Test_FiveThree_Functional_EngineTest extends PHPUnit_Framework_Te
         $helpers = array(
             'longdate' => function (\DateTime $value) {
                 return $value->format('Y-m-d h:m:s');
-            }
+            },
         );
 
         $data = array(

--- a/test/Mustache/Test/FiveThree/Functional/FiltersTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/FiltersTest.php
@@ -47,14 +47,14 @@ class Mustache_Test_FiveThree_Functional_FiltersTest extends PHPUnit_Framework_T
                 '{{% FILTERS }}{{ date | longdate }}',
                 $helpers,
                 (object) array('date' => new DateTime('1/1/2000', new DateTimeZone("UTC"))),
-                '2000-01-01 12:01:00'
+                '2000-01-01 12:01:00',
             ),
 
             array(
                 '{{% FILTERS }}{{# word | echo }}{{ . }}!{{/ word | echo }}',
                 $helpers,
                 array('word' => 'bacon'),
-                'bacon!bacon!bacon!'
+                'bacon!bacon!bacon!',
             ),
         );
     }

--- a/test/Mustache/Test/FiveThree/Functional/HigherOrderSectionsTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/HigherOrderSectionsTest.php
@@ -55,7 +55,7 @@ class Mustache_Test_FiveThree_Functional_HigherOrderSectionsTest extends PHPUnit
             'name' => 'Bob',
             'wrap' => function ($text) {
                 return sprintf('[[%s]]', $text);
-            }
+            },
         );
 
         $this->assertEquals(sprintf('[[%s]]', $data['name']), $tpl->render($data));

--- a/test/Mustache/Test/FiveThree/Functional/PartialLambdaIndentTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/PartialLambdaIndentTest.php
@@ -36,7 +36,7 @@ EOS;
 EOS;
 
         $m = new Mustache_Engine(array(
-            'partials' => array('input' => $partial)
+            'partials' => array('input' => $partial),
         ));
 
         $tpl = $m->loadTemplate($src);

--- a/test/Mustache/Test/Functional/ExamplesTest.php
+++ b/test/Mustache/Test/Functional/ExamplesTest.php
@@ -28,7 +28,7 @@ class Mustache_Test_Functional_ExamplesTest extends PHPUnit_Framework_TestCase
     public function testExamples($context, $source, $partials, $expected)
     {
         $mustache = new Mustache_Engine(array(
-            'partials' => $partials
+            'partials' => $partials,
         ));
         $this->assertEquals($expected, $mustache->loadTemplate($source)->render($context));
     }

--- a/test/Mustache/Test/Functional/InheritanceTest.php
+++ b/test/Mustache/Test/Functional/InheritanceTest.php
@@ -24,13 +24,13 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
                     'foo' => '{{$baz}}default content{{/baz}}',
                 ),
                 array(
-                    'bar' => 'set by user'
+                    'bar' => 'set by user',
                 ),
                 '{{< foo }}{{# bar }}{{$ baz }}{{/ baz }}{{/ bar }}{{/ foo }}',
             ),
             array(
                 array(
-                    'foo' => '{{$baz}}default content{{/baz}}'
+                    'foo' => '{{$baz}}default content{{/baz}}',
                 ),
                 array(
                 ),
@@ -39,19 +39,19 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
             array(
                 array(
                     'foo' => '{{$baz}}default content{{/baz}}',
-                    'qux' => 'I am a partial'
+                    'qux' => 'I am a partial',
                 ),
                 array(
                 ),
-                '{{<foo}}{{>qux}}{{$baz}}set by template{{/baz}}{{/foo}}'
+                '{{<foo}}{{>qux}}{{$baz}}set by template{{/baz}}{{/foo}}',
             ),
             array(
                 array(
-                    'foo' => '{{$baz}}default content{{/baz}}'
+                    'foo' => '{{$baz}}default content{{/baz}}',
                 ),
                 array(),
-                '{{<foo}}{{=<% %>=}}<%={{ }}=%>{{/foo}}'
-            )
+                '{{<foo}}{{=<% %>=}}<%={{ }}=%>{{/foo}}',
+            ),
         );
     }
 
@@ -63,28 +63,28 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
                     'foo' => '{{$baz}}default content{{/baz}}',
                 ),
                 array(
-                    'bar' => 'set by user'
+                    'bar' => 'set by user',
                 ),
                 '{{<foo}}{{bar}}{{$baz}}override{{/baz}}{{/foo}}',
-                'override'
+                'override',
             ),
             array(
                 array(
-                    'foo' => '{{$baz}}default content{{/baz}}'
+                    'foo' => '{{$baz}}default content{{/baz}}',
                 ),
                 array(
                 ),
                 '{{<foo}}{{! ignore me }}{{$baz}}set by template{{/baz}}{{/foo}}',
-                'set by template'
+                'set by template',
             ),
             array(
                 array(
-                    'foo' => '{{$baz}}defualt content{{/baz}}'
+                    'foo' => '{{$baz}}defualt content{{/baz}}',
                 ),
                 array(),
                 '{{<foo}}set by template{{$baz}}also set by template{{/baz}}{{/foo}}',
-                'also set by template'
-            )
+                'also set by template',
+            ),
         );
     }
 
@@ -102,7 +102,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
         $tpl = $this->mustache->loadTemplate('{{$foo}}default {{bar}} content{{/foo}}');
 
         $data = array(
-            'bar' => 'baz'
+            'bar' => 'baz',
         );
 
         $this->assertEquals('default baz content', $tpl->render($data));
@@ -113,7 +113,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
         $tpl = $this->mustache->loadTemplate('{{$foo}}default {{{bar}}} content{{/foo}}');
 
         $data = array(
-            'bar' => '<baz>'
+            'bar' => '<baz>',
         );
 
         $this->assertEquals('default <baz> content', $tpl->render($data));
@@ -126,7 +126,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
         );
 
         $data = array(
-            'bar' => array('baz' => 'qux')
+            'bar' => array('baz' => 'qux'),
         );
 
         $this->assertEquals('default qux content', $tpl->render($data));
@@ -140,7 +140,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
 
         $data = array(
             'foo' => array('bar' => 'qux'),
-            'baz' => 'three'
+            'baz' => 'three',
         );
 
         $this->assertEquals('default three content', $tpl->render($data));
@@ -153,7 +153,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
         );
 
         $data = array(
-            'bar' => array('baz' => '{{qux}}')
+            'bar' => array('baz' => '{{qux}}'),
         );
 
         $this->assertEquals('default {{qux}} content', $tpl->render($data));
@@ -162,7 +162,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
     public function testDefaultContentRenderedInsideIncludedTemplates()
     {
         $partials = array(
-            'include' => '{{$foo}}default content{{/foo}}'
+            'include' => '{{$foo}}default content{{/foo}}',
         );
 
         $this->mustache->setPartials($partials);
@@ -179,7 +179,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
     public function testOverriddenContent()
     {
         $partials = array(
-            'super' => '...{{$title}}Default title{{/title}}...'
+            'super' => '...{{$title}}Default title{{/title}}...',
         );
 
         $this->mustache->setPartials($partials);
@@ -196,7 +196,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
     public function testOverriddenPartial()
     {
         $partials = array(
-            'partial' => '|{{$stuff}}...{{/stuff}}{{$default}} default{{/default}}|'
+            'partial' => '|{{$stuff}}...{{/stuff}}{{$default}} default{{/default}}|',
         );
 
         $this->mustache->setPartials($partials);
@@ -213,7 +213,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
     public function testDataDoesNotOverrideBlock()
     {
         $partials = array(
-            'include' => '{{$var}}var in include{{/var}}'
+            'include' => '{{$var}}var in include{{/var}}',
         );
 
         $this->mustache->setPartials($partials);
@@ -223,7 +223,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
         );
 
         $data = array(
-            'var' => 'var in data'
+            'var' => 'var in data',
         );
 
         $this->assertEquals('var in template', $tpl->render($data));
@@ -232,7 +232,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
     public function testDataDoesNotOverrideDefaultBlockValue()
     {
         $partials = array(
-            'include' => '{{$var}}var in include{{/var}}'
+            'include' => '{{$var}}var in include{{/var}}',
         );
 
         $this->mustache->setPartials($partials);
@@ -242,7 +242,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
         );
 
         $data = array(
-            'var' => 'var in data'
+            'var' => 'var in data',
         );
 
         $this->assertEquals('var in include', $tpl->render($data));
@@ -251,7 +251,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
     public function testOverridePartialWithNewlines()
     {
         $partials = array(
-            'partial' => '{{$ballmer}}peaking{{/ballmer}}'
+            'partial' => '{{$ballmer}}peaking{{/ballmer}}',
         );
 
         $this->mustache->setPartials($partials);
@@ -270,7 +270,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
         $partials = array(
             'partial' =>
                 'stop:
-                    {{$nineties}}collaborate and listen{{/nineties}}'
+                    {{$nineties}}collaborate and listen{{/nineties}}',
         );
 
         $this->mustache->setPartials($partials);
@@ -291,7 +291,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
     public function testOverrideOneSubstitutionButNotTheOther()
     {
         $partials = array(
-            'partial' => '{{$stuff}}default one{{/stuff}}, {{$stuff2}}default two{{/stuff2}}'
+            'partial' => '{{$stuff}}default one{{/stuff}}, {{$stuff2}}default two{{/stuff2}}',
         );
 
         $this->mustache->setPartials($partials);
@@ -308,7 +308,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
     public function testSuperTemplatesWithNoParameters()
     {
         $partials = array(
-            'include' => '{{$foo}}default content{{/foo}}'
+            'include' => '{{$foo}}default content{{/foo}}',
         );
 
         $this->mustache->setPartials($partials);
@@ -326,7 +326,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
     {
         $partials = array(
             'include' => '{{$foo}}default content{{/foo}} {{$bar}}{{<include2}}{{/include2}}{{/bar}}',
-            'include2' => '{{$foo}}include2 default content{{/foo}} {{<include}}{{$bar}}don\'t recurse{{/bar}}{{/include}}'
+            'include2' => '{{$foo}}include2 default content{{/foo}} {{<include}}{{$bar}}don\'t recurse{{/bar}}{{/include}}',
         );
 
         $this->mustache->setPartials($partials);
@@ -345,7 +345,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
         $partials = array(
             'parent' => '{{<older}}{{$a}}p{{/a}}{{/older}}',
             'older' => '{{<grandParent}}{{$a}}o{{/a}}{{/grandParent}}',
-            'grandParent' => '{{$a}}g{{/a}}'
+            'grandParent' => '{{$a}}g{{/a}}',
         );
 
         $this->mustache->setPartials($partials);
@@ -364,7 +364,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
         $partials = array(
             'parent' => '{{<older}}{{$a}}p{{/a}}{{/older}}',
             'older' => '{{<grandParent}}{{$a}}o{{/a}}{{/grandParent}}',
-            'grandParent' => '{{$a}}g{{/a}}'
+            'grandParent' => '{{$a}}g{{/a}}',
         );
 
         $this->mustache->setPartials($partials);
@@ -381,7 +381,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
     public function testIgnoreTextInsideSuperTemplatesButParseArgs()
     {
         $partials = array(
-            'include' => '{{$foo}}default content{{/foo}}'
+            'include' => '{{$foo}}default content{{/foo}}',
          );
 
         $this->mustache->setPartials($partials);
@@ -398,7 +398,7 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
     public function testIgnoreTextInsideSuperTemplates()
     {
         $partials = array(
-            'include' => '{{$foo}}default content{{/foo}}'
+            'include' => '{{$foo}}default content{{/foo}}',
          );
 
         $this->mustache->setPartials($partials);

--- a/test/Mustache/Test/Functional/MustacheInjectionTest.php
+++ b/test/Mustache/Test/Functional/MustacheInjectionTest.php
@@ -35,25 +35,25 @@ class Mustache_Test_Functional_MustacheInjectionTest extends PHPUnit_Framework_T
     {
         $interpolationData = array(
             'a' => '{{ b }}',
-            'b' => 'FAIL'
+            'b' => 'FAIL',
         );
 
         $sectionData = array(
             'a' => true,
             'b' => '{{ c }}',
-            'c' => 'FAIL'
+            'c' => 'FAIL',
         );
 
         $lambdaInterpolationData = array(
             'a' => array($this, 'lambdaInterpolationCallback'),
             'b' => '{{ c }}',
-            'c' => 'FAIL'
+            'c' => 'FAIL',
         );
 
         $lambdaSectionData = array(
             'a' => array($this, 'lambdaSectionCallback'),
             'b' => '{{ c }}',
-            'c' => 'FAIL'
+            'c' => 'FAIL',
         );
 
         return array(

--- a/test/Mustache/Test/Functional/NestedPartialIndentTest.php
+++ b/test/Mustache/Test/Functional/NestedPartialIndentTest.php
@@ -21,7 +21,7 @@ class Mustache_Test_Functional_NestedPartialIndentTest extends PHPUnit_Framework
     public function testNestedPartialsAreIndentedProperly($src, array $partials, $expected)
     {
         $m = new Mustache_Engine(array(
-            'partials' => $partials
+            'partials' => $partials,
         ));
         $tpl = $m->loadTemplate($src);
         $this->assertEquals($expected, $tpl->render());

--- a/test/Mustache/Test/Loader/ArrayLoaderTest.php
+++ b/test/Mustache/Test/Loader/ArrayLoaderTest.php
@@ -17,7 +17,7 @@ class Mustache_Test_Loader_ArrayLoaderTest extends PHPUnit_Framework_TestCase
     public function testConstructor()
     {
         $loader = new Mustache_Loader_ArrayLoader(array(
-            'foo' => 'bar'
+            'foo' => 'bar',
         ));
 
         $this->assertEquals('bar', $loader->load('foo'));
@@ -26,7 +26,7 @@ class Mustache_Test_Loader_ArrayLoaderTest extends PHPUnit_Framework_TestCase
     public function testSetAndLoadTemplates()
     {
         $loader = new Mustache_Loader_ArrayLoader(array(
-            'foo' => 'bar'
+            'foo' => 'bar',
         ));
         $this->assertEquals('bar', $loader->load('foo'));
 

--- a/test/Mustache/Test/Logger/StreamLoggerTest.php
+++ b/test/Mustache/Test/Logger/StreamLoggerTest.php
@@ -134,7 +134,7 @@ class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
                 Mustache_Logger::ERROR,
                 'error message',
                 array('name' => 'foo', 'number' => 42),
-                "ERROR: error message\n"
+                "ERROR: error message\n",
             ),
 
             // with interpolation
@@ -142,7 +142,7 @@ class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
                 Mustache_Logger::ERROR,
                 'error {name}-{number}',
                 array('name' => 'foo', 'number' => 42),
-                "ERROR: error foo-42\n"
+                "ERROR: error foo-42\n",
             ),
 
             // with iterpolation false positive
@@ -150,7 +150,7 @@ class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
                 Mustache_Logger::ERROR,
                 'error {nothing}',
                 array('name' => 'foo', 'number' => 42),
-                "ERROR: error {nothing}\n"
+                "ERROR: error {nothing}\n",
             ),
 
             // with interpolation injection
@@ -158,7 +158,7 @@ class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
                 Mustache_Logger::ERROR,
                 '{foo}',
                 array('foo' => '{bar}', 'bar' => 'FAIL'),
-                "ERROR: {bar}\n"
+                "ERROR: {bar}\n",
             ),
         );
     }

--- a/test/Mustache/Test/ParserTest.php
+++ b/test/Mustache/Test/ParserTest.php
@@ -28,7 +28,7 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
         return array(
             array(
                 array(),
-                array()
+                array(),
             ),
 
             array(
@@ -48,12 +48,12 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                 array(array(
                     Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_ESCAPED,
                     Mustache_Tokenizer::LINE => 0,
-                    Mustache_Tokenizer::NAME => 'name'
+                    Mustache_Tokenizer::NAME => 'name',
                 )),
                 array(array(
                     Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_ESCAPED,
                     Mustache_Tokenizer::LINE => 0,
-                    Mustache_Tokenizer::NAME => 'name'
+                    Mustache_Tokenizer::NAME => 'name',
                 )),
             ),
 
@@ -62,29 +62,29 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                     array(
                         Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_TEXT,
                         Mustache_Tokenizer::LINE  => 0,
-                        Mustache_Tokenizer::VALUE => 'foo'
+                        Mustache_Tokenizer::VALUE => 'foo',
                     ),
                     array(
                         Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_INVERTED,
                         Mustache_Tokenizer::LINE  => 0,
                         Mustache_Tokenizer::INDEX => 123,
-                        Mustache_Tokenizer::NAME  => 'parent'
+                        Mustache_Tokenizer::NAME  => 'parent',
                     ),
                     array(
                         Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_ESCAPED,
                         Mustache_Tokenizer::LINE  => 0,
-                        Mustache_Tokenizer::NAME  => 'name'
+                        Mustache_Tokenizer::NAME  => 'name',
                     ),
                     array(
                         Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_END_SECTION,
                         Mustache_Tokenizer::LINE  => 0,
                         Mustache_Tokenizer::INDEX => 456,
-                        Mustache_Tokenizer::NAME  => 'parent'
+                        Mustache_Tokenizer::NAME  => 'parent',
                     ),
                     array(
                         Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_TEXT,
                         Mustache_Tokenizer::LINE  => 0,
-                        Mustache_Tokenizer::VALUE => 'bar'
+                        Mustache_Tokenizer::VALUE => 'bar',
                     ),
                 ),
 
@@ -92,7 +92,7 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                     array(
                         Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_TEXT,
                         Mustache_Tokenizer::LINE  => 0,
-                        Mustache_Tokenizer::VALUE => 'foo'
+                        Mustache_Tokenizer::VALUE => 'foo',
                     ),
                     array(
                         Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_INVERTED,
@@ -104,14 +104,14 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                             array(
                                 Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_ESCAPED,
                                 Mustache_Tokenizer::LINE => 0,
-                                Mustache_Tokenizer::NAME => 'name'
+                                Mustache_Tokenizer::NAME => 'name',
                             ),
                         ),
                     ),
                     array(
                         Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_TEXT,
                         Mustache_Tokenizer::LINE  => 0,
-                        Mustache_Tokenizer::VALUE => 'bar'
+                        Mustache_Tokenizer::VALUE => 'bar',
                     ),
                 ),
             ),
@@ -130,7 +130,7 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_TEXT,
                         Mustache_Tokenizer::LINE => 0,
-                        Mustache_Tokenizer::VALUE => 'bar'
+                        Mustache_Tokenizer::VALUE => 'bar',
                     ),
                 ),
                 array(
@@ -144,7 +144,7 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_TEXT,
                         Mustache_Tokenizer::LINE => 0,
-                        Mustache_Tokenizer::VALUE => 'bar'
+                        Mustache_Tokenizer::VALUE => 'bar',
                     ),
                 ),
             ),
@@ -208,7 +208,7 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::OTAG => '{{',
                         Mustache_Tokenizer::CTAG => '}}',
                         Mustache_Tokenizer::LINE => 0,
-                        Mustache_Tokenizer::INDEX => 8
+                        Mustache_Tokenizer::INDEX => 8,
                     ),
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_BLOCK_VAR,
@@ -216,12 +216,12 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::OTAG => '{{',
                         Mustache_Tokenizer::CTAG => '}}',
                         Mustache_Tokenizer::LINE => 0,
-                        Mustache_Tokenizer::INDEX => 16
+                        Mustache_Tokenizer::INDEX => 16,
                     ),
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_TEXT,
                         Mustache_Tokenizer::LINE => 0,
-                        Mustache_Tokenizer::VALUE => 'baz'
+                        Mustache_Tokenizer::VALUE => 'baz',
                     ),
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_END_SECTION,
@@ -229,7 +229,7 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::OTAG => '{{',
                         Mustache_Tokenizer::CTAG => '}}',
                         Mustache_Tokenizer::LINE => 0,
-                        Mustache_Tokenizer::INDEX => 19
+                        Mustache_Tokenizer::INDEX => 19,
                     ),
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_END_SECTION,
@@ -237,8 +237,8 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::OTAG => '{{',
                         Mustache_Tokenizer::CTAG => '}}',
                         Mustache_Tokenizer::LINE => 0,
-                        Mustache_Tokenizer::INDEX => 27
-                    )
+                        Mustache_Tokenizer::INDEX => 27,
+                    ),
                 ),
                 array(
                     array(
@@ -262,13 +262,13 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                                     array(
                                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_TEXT,
                                         Mustache_Tokenizer::LINE => 0,
-                                        Mustache_Tokenizer::VALUE => 'baz'
-                                    )
-                                )
-                            )
-                        )
-                    )
-                )
+                                        Mustache_Tokenizer::VALUE => 'baz',
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
             ),
 
             array(
@@ -283,7 +283,7 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_TEXT,
                         Mustache_Tokenizer::LINE => 0,
-                        Mustache_Tokenizer::VALUE => 'bar'
+                        Mustache_Tokenizer::VALUE => 'bar',
                     ),
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_END_SECTION,
@@ -306,11 +306,11 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                             array(
                                 Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_TEXT,
                                 Mustache_Tokenizer::LINE => 0,
-                                Mustache_Tokenizer::VALUE => 'bar'
-                            )
-                        )
-                    )
-                )
+                                Mustache_Tokenizer::VALUE => 'bar',
+                            ),
+                        ),
+                    ),
+                ),
             ),
         );
     }
@@ -408,7 +408,7 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_TEXT,
                         Mustache_Tokenizer::LINE => 0,
-                        Mustache_Tokenizer::VALUE => 'bar'
+                        Mustache_Tokenizer::VALUE => 'bar',
                     ),
                     array(
                         Mustache_Tokenizer::TYPE => Mustache_Tokenizer::T_END_SECTION,

--- a/test/Mustache/Test/TokenizerTest.php
+++ b/test/Mustache/Test/TokenizerTest.php
@@ -83,8 +83,8 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::CTAG  => '}}',
                         Mustache_Tokenizer::LINE  => 0,
                         Mustache_Tokenizer::INDEX => 10,
-                    )
-                )
+                    ),
+                ),
             ),
 
             array(
@@ -110,8 +110,8 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::CTAG  => '>>>',
                         Mustache_Tokenizer::LINE  => 0,
                         Mustache_Tokenizer::INDEX => 12,
-                    )
-                )
+                    ),
+                ),
             ),
 
             array(
@@ -178,7 +178,7 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::INDEX => 51,
                     ),
 
-                )
+                ),
             ),
 
             // See https://github.com/bobthecow/mustache.php/issues/183
@@ -207,7 +207,7 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::LINE  => 0,
                         Mustache_Tokenizer::INDEX => 9,
                     ),
-                )
+                ),
             ),
 
             // custom delimiters don't swallow the next character, even if it is a }, }}}, or the same delimiter
@@ -254,7 +254,7 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::LINE  => 0,
                         Mustache_Tokenizer::VALUE => "}}}",
                     ),
-                )
+                ),
             ),
 
             // unescaped custom delimiters are properly parsed
@@ -269,8 +269,8 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::CTAG  => '%>',
                         Mustache_Tokenizer::LINE  => 0,
                         Mustache_Tokenizer::INDEX => 9,
-                    )
-                )
+                    ),
+                ),
             ),
 
             // Ensure that $arg token is not picked up during tokenization
@@ -284,7 +284,7 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::OTAG => '{{',
                         Mustache_Tokenizer::CTAG => '}}',
                         Mustache_Tokenizer::LINE => 0,
-                        Mustache_Tokenizer::INDEX => 8
+                        Mustache_Tokenizer::INDEX => 8,
                     ),
                     array(
                         Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_TEXT,
@@ -298,8 +298,8 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
                         Mustache_Tokenizer::CTAG  => '}}',
                         Mustache_Tokenizer::LINE  => 0,
                         Mustache_Tokenizer::INDEX => 15,
-                    )
-                )
+                    ),
+                ),
             ),
         );
     }

--- a/test/fixtures/examples/dot_notation/DotNotation.php
+++ b/test/fixtures/examples/dot_notation/DotNotation.php
@@ -8,7 +8,7 @@ class DotNotation
         'hometown' => array(
             'city'  => 'Cincinnati',
             'state' => 'OH',
-        )
+        ),
     );
 
     public $normal = 'Normal';

--- a/test/fixtures/examples/grand_parent_context/GrandParentContext.php
+++ b/test/fixtures/examples/grand_parent_context/GrandParentContext.php
@@ -9,14 +9,14 @@ class GrandParentContext
     {
         $this->parent_contexts[] = array('parent_id' => 'parent1', 'child_contexts' => array(
             array('child_id' => 'parent1-child1'),
-            array('child_id' => 'parent1-child2')
+            array('child_id' => 'parent1-child2'),
         ));
 
         $parent2 = new stdClass();
         $parent2->parent_id = 'parent2';
         $parent2->child_contexts = array(
             array('child_id' => 'parent2-child1'),
-            array('child_id' => 'parent2-child2')
+            array('child_id' => 'parent2-child2'),
         );
 
         $this->parent_contexts[] = $parent2;

--- a/test/fixtures/examples/recursive_partials/RecursivePartials.php
+++ b/test/fixtures/examples/recursive_partials/RecursivePartials.php
@@ -8,6 +8,6 @@ class RecursivePartials
         'child' => array(
             'name'  => 'Justin',
             'child' => false,
-        )
+        ),
     );
 }

--- a/test/fixtures/examples/section_magic_objects/SectionMagicObjects.php
+++ b/test/fixtures/examples/section_magic_objects/SectionMagicObjects.php
@@ -16,7 +16,7 @@ class MagicObject
 {
     protected $_data = array(
         'foo' => 'And it worked the second time.',
-        'bar' => 'As well as the third.'
+        'bar' => 'As well as the third.',
     );
 
     public function __get($key)

--- a/test/fixtures/examples/sections_nested/SectionsNested.php
+++ b/test/fixtures/examples/sections_nested/SectionsNested.php
@@ -13,7 +13,7 @@ class SectionsNested
                     array('name' => 'Super Macho Man'),
                     array('name' => 'Piston Honda'),
                     array('name' => 'Mr. Sandman'),
-                )
+                ),
             ),
             array(
                 'name' => 'Mike Tyson',
@@ -22,13 +22,13 @@ class SectionsNested
                     array('name' => 'King Hippo'),
                     array('name' => 'Great Tiger'),
                     array('name' => 'Glass Joe'),
-                )
+                ),
             ),
             array(
                 'name' => 'Don Flamenco',
                 'enemies' => array(
                     array('name' => 'Bald Bull'),
-                )
+                ),
             ),
         );
     }


### PR DESCRIPTION
There is a bug on PHP CS Fixer, so fixing was made on [my branch](https://github.com/keradus/PHP-CS-Fixer/tree/tokens-transform) as a part of regress if fix work.
