### PR TITLE
.travis.yml - no need for sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ php:
   - hhvm
   - hhvm-nightly
 
+sudo: false
+
 matrix:
   allow_failures:
     - php: hhvm-nightly


### PR DESCRIPTION
No need for sudo in Travis jobs.
See http://docs.travis-ci.com/user/workers/container-based-infrastructure/ for details
