### PR TITLE
Allow multiple search (base) directories in filesystem loader.

### DIFF
--- a/src/Mustache/Loader/FilesystemLoader.php
+++ b/src/Mustache/Loader/FilesystemLoader.php
@@ -48,7 +48,7 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
     public function __construct($baseDir, array $options = array())
     {
         if (is_array($baseDir)) {
-            $this->baseDir = [];
+            $this->baseDir = array();
             foreach ($baseDir as $dir) {
                 $this->baseDir[] = $this->sanitizeDir($dir);
             }
@@ -87,7 +87,7 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
         if (!is_dir($dir)) {
             throw new Mustache_Exception_RuntimeException(sprintf('FilesystemLoader baseDir must be a directory: %s', $dir));
         }
-        
+    
         return $dir;
     }
 

--- a/src/Mustache/Loader/FilesystemLoader.php
+++ b/src/Mustache/Loader/FilesystemLoader.php
@@ -52,17 +52,14 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
             foreach ($baseDir as $dir) {
                 $this->baseDir[] = $this->sanitizeDir($dir);
             }
-        }
-        else {
+        } else {
             $this->baseDir = array($this->sanitizeDir($baseDir));
         }
-
 
         if (empty($this->baseDir)) {
             throw new Mustache_Exception_RuntimeException('FilesystemLoader baseDir must have at least one directory.');
         }
 
-        
         if (array_key_exists('extension', $options)) {
             if (empty($options['extension'])) {
                 $this->extension = '';
@@ -73,7 +70,7 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
     }
 
     /**
-     * Sanitize a directory name
+     * Sanitize a directory name.
      *
      * @throws Mustache_Exception_RuntimeException
      *
@@ -81,7 +78,7 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
     protected function sanitizeDir($dir)
     {
         if (strpos($dir, '://') === false) {
-            $dir= realpath($dir);
+            $dir = realpath($dir);
         }
 
         if (!is_dir($dir)) {
@@ -140,7 +137,7 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
      *
      * @return string Template file name
      */
-    protected function getFileName($name, $dir=null)
+    protected function getFileName($name, $dir = null)
     {
         $fileName = $dir . '/' . $name;
         if (substr($fileName, 0 - strlen($this->extension)) !== $this->extension) {

--- a/src/Mustache/Loader/FilesystemLoader.php
+++ b/src/Mustache/Loader/FilesystemLoader.php
@@ -47,16 +47,22 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
      */
     public function __construct($baseDir, array $options = array())
     {
-        $this->baseDir = $baseDir;
-
-        if (strpos($this->baseDir, '://') === false) {
-            $this->baseDir = realpath($this->baseDir);
+        if (is_array($baseDir)) {
+            $this->baseDir = [];
+            foreach ($baseDir as $dir) {
+                $this->baseDir[] = $this->sanitizeDir($dir);
+            }
+        }
+        else {
+            $this->baseDir = array($this->sanitizeDir($baseDir));
         }
 
-        if (!is_dir($this->baseDir)) {
-            throw new Mustache_Exception_RuntimeException(sprintf('FilesystemLoader baseDir must be a directory: %s', $baseDir));
+
+        if (empty($this->baseDir)) {
+            throw new Mustache_Exception_RuntimeException('FilesystemLoader baseDir must have at least one directory.');
         }
 
+        
         if (array_key_exists('extension', $options)) {
             if (empty($options['extension'])) {
                 $this->extension = '';
@@ -64,6 +70,24 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
                 $this->extension = '.' . ltrim($options['extension'], '.');
             }
         }
+    }
+
+    /**
+     * Sanitize a directory name
+     *
+     * @throws Mustache_Exception_RuntimeException
+     *
+     */
+    protected function sanitizeDir($dir)
+    {
+        if (strpos($dir, '://') === false) {
+            $dir= realpath($dir);
+        }
+
+        if (!is_dir($dir)) {
+            throw new Mustache_Exception_RuntimeException(sprintf('FilesystemLoader baseDir must be a directory: %s', $dir));
+        }
+        return $dir;
     }
 
     /**
@@ -96,25 +120,29 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
      */
     protected function loadFile($name)
     {
-        $fileName = $this->getFileName($name);
+        foreach ($this->baseDir as $dir) {
+            $fileName = $this->getFileName($name, $dir);
 
-        if (!file_exists($fileName)) {
-            throw new Mustache_Exception_UnknownTemplateException($name);
+            if (file_exists($fileName)) {
+                return file_get_contents($fileName);
+            }
         }
 
-        return file_get_contents($fileName);
+        // No template found
+        throw new Mustache_Exception_UnknownTemplateException($name);
     }
 
     /**
      * Helper function for getting a Mustache template file name.
      *
      * @param string $name
+     * @param string $dir
      *
      * @return string Template file name
      */
-    protected function getFileName($name)
+    protected function getFileName($name, $dir=null)
     {
-        $fileName = $this->baseDir . '/' . $name;
+        $fileName = $dir . '/' . $name;
         if (substr($fileName, 0 - strlen($this->extension)) !== $this->extension) {
             $fileName .= $this->extension;
         }

--- a/src/Mustache/Loader/FilesystemLoader.php
+++ b/src/Mustache/Loader/FilesystemLoader.php
@@ -74,6 +74,9 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
      *
      * @throws Mustache_Exception_RuntimeException
      *
+     * @param string $dir
+     *
+     * @return string
      */
     protected function sanitizeDir($dir)
     {
@@ -84,6 +87,7 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
         if (!is_dir($dir)) {
             throw new Mustache_Exception_RuntimeException(sprintf('FilesystemLoader baseDir must be a directory: %s', $dir));
         }
+        
         return $dir;
     }
 


### PR DESCRIPTION
Allow to pass an array as the Filesystem Loader constructor parameter.
When calling `load()`, the template file will be searched in all
directories and return the first match.