### PR TITLE
Add global variables option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You have just won {{value}} dollars!
 {{#in_ca}}
 Well, {{taxed_value}} dollars, after taxes.
 {{/in_ca}}
+contact us at {{system}}
 ```
 
 
@@ -52,7 +53,7 @@ And render it:
 
 ```php
 <?php
-$m = new Mustache_Engine;
+$m = new Mustache_Engine(array('global_variables' => array('system' => 'contact@example.com')));
 $chris = new Chris;
 echo $m->render($template, $chris);
 ```

--- a/src/Mustache/Engine.php
+++ b/src/Mustache/Engine.php
@@ -54,6 +54,7 @@ class Mustache_Engine
     private $logger;
     private $strictCallables = false;
     private $pragmas = array();
+    private $global_variables = array();
 
     // Services
     private $tokenizer;
@@ -124,6 +125,9 @@ class Mustache_Engine
      *         // Enable pragmas across all templates, regardless of the presence of pragma tags in the individual
      *         // templates.
      *         'pragmas' => [Mustache_Engine::PRAGMA_FILTERS],
+     * 
+     *         // Add global variables across all templates
+     *         'global_variables' => ['globalKey' => 'globalValue'],
      *     );
      *
      * @throws Mustache_Exception_InvalidArgumentException If `escape` option is not callable.
@@ -199,6 +203,10 @@ class Mustache_Engine
                 $this->pragmas[$pragma] = true;
             }
         }
+        
+        if (isset($options['global_variables'])) {
+            $this->global_variables = $options['global_variables'];
+        }
     }
 
     /**
@@ -216,7 +224,7 @@ class Mustache_Engine
      */
     public function render($template, $context = array())
     {
-        return $this->loadTemplate($template)->render($context);
+        return $this->loadTemplate($template)->render($context, $this->global_variables);
     }
 
     /**
@@ -257,6 +265,16 @@ class Mustache_Engine
     public function getPragmas()
     {
         return array_keys($this->pragmas);
+    }
+
+    /**
+     * Get the current globally enabled variables.
+     *
+     * @return mixed array|object
+     */
+    public function getGlobalVariables()
+    {
+        return $this->global_variables;
     }
 
     /**

--- a/src/Mustache/Template.php
+++ b/src/Mustache/Template.php
@@ -58,13 +58,14 @@ abstract class Mustache_Template
      * Render this template given the rendering context.
      *
      * @param mixed $context Array or object rendering context (default: array())
+     * @param mixed $globalContext Array or object rendering context (default: array())
      *
      * @return string Rendered template
      */
-    public function render($context = array())
+    public function render($context = array(), $globalContext = array())
     {
         return $this->renderInternal(
-            $this->prepareContextStack($context)
+            $this->prepareContextStack($context, $globalContext)
         );
     }
 
@@ -138,12 +139,13 @@ abstract class Mustache_Template
      * Adds the Mustache HelperCollection to the stack's top context frame if helpers are present.
      *
      * @param mixed $context Optional first context frame (default: null)
+     * @param mixed $globalContext Optional second context frame (default: null)
      *
      * @return Mustache_Context
      */
-    protected function prepareContextStack($context = null)
+    protected function prepareContextStack($context = null, $globalContext = null)
     {
-        $stack = new Mustache_Context();
+        $stack = new Mustache_Context($globalContext);
 
         $helpers = $this->mustache->getHelpers();
         if (!$helpers->isEmpty()) {

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -16,6 +16,7 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
 {
     public function testConstructor()
     {
+        $global_variables = array('globalKey' => 'globalValue');
         $logger         = new Mustache_Logger_StreamLogger(tmpfile());
         $loader         = new Mustache_Loader_StringLoader();
         $partialsLoader = new Mustache_Loader_ArrayLoader();
@@ -37,6 +38,7 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
             'entity_flags' => ENT_QUOTES,
             'charset'      => 'ISO-8859-1',
             'pragmas'      => array(Mustache_Engine::PRAGMA_FILTERS),
+            'global_variables' => $global_variables
         ));
 
         $this->assertSame($logger, $mustache->getLogger());
@@ -52,6 +54,7 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         $this->assertFalse($mustache->hasHelper('baz'));
         $this->assertInstanceOf('Mustache_Cache_FilesystemCache', $mustache->getCache());
         $this->assertEquals(array(Mustache_Engine::PRAGMA_FILTERS), $mustache->getPragmas());
+        $this->assertEquals($global_variables, $mustache->getGlobalVariables());
     }
 
     public static function getFoo()
@@ -79,6 +82,29 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
 
         $this->assertEquals($output, $mustache->render($source, $data));
         $this->assertEquals($source, $mustache->source);
+    }
+    
+    public function testRenderWithGlobalVariablesArray()
+    {
+        $source = '{{ foo }} {{ bar }}';
+        $data   = array('bar' => 'baz');
+        $output = 'fo baz';
+
+        $mustache = new Mustache_Engine(/*$options =*/array('global_variables' => array('foo' => 'fo')));
+
+        $this->assertEquals($output, $mustache->render($source, $data));
+    }
+    
+    public function testRenderWithGlobalVariablesObject()
+    {
+        
+        $source = '{{ bar }} {{ taxed_value }}';
+        $data   = array('bar' => 'baz');
+        $output = 'baz 6000';
+
+        $mustache = new Mustache_Engine(/*$options =*/array('global_variables' => new globalVariablesObject));
+
+        $this->assertEquals($output, $mustache->render($source, $data));
     }
 
     public function testSettingServices()
@@ -358,4 +384,15 @@ class MustacheStub extends Mustache_Engine
     {
         return $this->getLambdaCache();
     }
+}
+
+class globalVariablesObject {
+    public $name  = "Chris";
+    public $value = 10000;
+
+    public function taxed_value() {
+        return $this->value - ($this->value * 0.4);
+    }
+
+    public $in_ca = true;
 }

--- a/test/Mustache/Test/TemplateTest.php
+++ b/test/Mustache/Test/TemplateTest.php
@@ -24,10 +24,11 @@ class Mustache_Test_TemplateTest extends PHPUnit_Framework_TestCase
     public function testRendering()
     {
         $rendered = '<< wheee >>';
-        $mustache = new Mustache_Engine();
+        $global_variables = array('globalKey' => 'globalValue');
+        $mustache = new Mustache_Engine(/*$options =*/array('global_variables' => $global_variables));
         $template = new Mustache_Test_TemplateStub($mustache);
         $template->rendered = $rendered;
-        $context  = new Mustache_Context();
+        $context  = new Mustache_Context(/*$context =*/$global_variables);
 
         if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
             $this->assertEquals($rendered, $template());
@@ -36,6 +37,7 @@ class Mustache_Test_TemplateTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($rendered, $template->render());
         $this->assertEquals($rendered, $template->renderInternal($context));
         $this->assertEquals($rendered, $template->render(array('foo' => 'bar')));
+        $this->assertEquals($rendered, $template->render(array('foo' => 'bar'), $global_variables));
     }
 }
 


### PR DESCRIPTION
Sometimes we need some variables to be accessible in all templates
- global_variables is a new optional key in options array passed to Mustache_Engine constructor
- global_variables can hold context which can be an array or an object
- global_variables will be seen in all templates

Example in README is updated with that change

Unit test impact is handled with the new change