### PR TITLE
Allow to load non-local templates

### DIFF
--- a/src/Mustache/Loader/FilesystemLoader.php
+++ b/src/Mustache/Loader/FilesystemLoader.php
@@ -51,10 +51,10 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
 
         if (strpos($this->baseDir, '://') === false) {
             $this->baseDir = realpath($this->baseDir);
-        }
 
-        if (!is_dir($this->baseDir)) {
-            throw new Mustache_Exception_RuntimeException(sprintf('FilesystemLoader baseDir must be a directory: %s', $baseDir));
+            if (!is_dir($this->baseDir)) {
+                throw new Mustache_Exception_RuntimeException(sprintf('FilesystemLoader baseDir must be a directory: %s', $baseDir));
+            }
         }
 
         if (array_key_exists('extension', $options)) {
@@ -98,7 +98,7 @@ class Mustache_Loader_FilesystemLoader implements Mustache_Loader
     {
         $fileName = $this->getFileName($name);
 
-        if (!file_exists($fileName)) {
+        if (strpos($this->baseDir, '://') === false && !file_exists($fileName)) {
             throw new Mustache_Exception_UnknownTemplateException($name);
         }
 

--- a/test/Mustache/Test/Loader/FilesystemLoaderTest.php
+++ b/test/Mustache/Test/Loader/FilesystemLoaderTest.php
@@ -33,7 +33,7 @@ class Mustache_Test_Loader_FilesystemLoaderTest extends PHPUnit_Framework_TestCa
     {
         $baseDir = realpath(dirname(__FILE__) . '/../../../fixtures/templates');
 
-        $loader = new Mustache_Loader_FilesystemLoader('file://' . $baseDir, array('extension' => '.ms'));
+        $loader = new Mustache_Loader_FilesystemLoader('test://' . $baseDir, array('extension' => '.ms'));
         $this->assertEquals('alpha contents', $loader->load('alpha'));
         $this->assertEquals('beta contents', $loader->load('beta.ms'));
     }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -14,3 +14,73 @@ Mustache_Autoloader::register();
 Mustache_Autoloader::register(dirname(__FILE__) . '/../test');
 
 require dirname(__FILE__) . '/../vendor/yaml/lib/sfYamlParser.php';
+
+/**
+ * Minimal stream wrapper to test protocol-based access to templates
+ */
+class TestStream
+{
+    private $filehandle;
+
+    /**
+     * Always returns false
+     *
+     * @param string $path
+     * @param int $flags
+     * @return array
+     */
+    public function url_stat($path, $flags)
+    {
+        return false;
+    }
+
+    /**
+     * Open the file
+     *
+     * @param string $path
+     * @param string $mode
+     * @return bool
+     */
+    public function stream_open($path, $mode)
+    {
+        $path = preg_replace('-^test://-', '', $path);
+        $this->filehandle = fopen($path, $mode);
+        return $this->filehandle !== false;
+    }
+
+    /**
+     * @return array
+     */
+    public function stream_stat()
+    {
+        return [];
+    }
+
+    /**
+     * @param int $count
+     * @return string
+     */
+    public function stream_read($count)
+    {
+        return fgets($this->filehandle, $count);
+    }
+
+    /**
+     * @return bool
+     */
+    public function stream_eof()
+    {
+        return feof($this->filehandle);
+    }
+
+    /**
+     * @return bool
+     */
+    public function stream_close()
+    {
+        return fclose($this->filehandle);
+    }
+}
+
+stream_wrapper_register('test', TestStream::class)
+    || die('Failed to register protocol');


### PR DESCRIPTION
I have modified the Mustache_Loader_FilesystemLoader such that checks for directory and file existence are only done when the baseDir is a local path. 

With this small modification, it is possible to pull templates from other streams that PHP permits, such as http. My use case is to pull templates from a remotely installed styleguide in Patternlab.

This should have been possible already. There was already a test testConstructorWithProtocol. However, due to the way PHP handles accesses through the "file://" protocol, this test did not catch the faulty behavior when using with protocols other than "file://". To make it actually detect errors, I have implemented a new protocol "test://" via a minimal stream wrapper in bootstrap.php.   