### PR TITLE
Add exception chaining

### DIFF
--- a/src/Mustache/Exception/SyntaxException.php
+++ b/src/Mustache/Exception/SyntaxException.php
@@ -17,13 +17,18 @@ class Mustache_Exception_SyntaxException extends LogicException implements Musta
     protected $token;
 
     /**
-     * @param string $msg
-     * @param array  $token
+     * @param string    $msg
+     * @param array     $token
+     * @param Exception $previous
      */
-    public function __construct($msg, array $token)
+    public function __construct($msg, array $token, Exception $previous = null)
     {
         $this->token = $token;
-        parent::__construct($msg);
+        if (method_exists(__CLASS__, 'getPrevious')) {
+            parent::__construct($msg, 0, $previous);
+        } else {
+            parent::__construct($msg);
+        }
     }
 
     /**

--- a/src/Mustache/Exception/UnknownFilterException.php
+++ b/src/Mustache/Exception/UnknownFilterException.php
@@ -17,12 +17,18 @@ class Mustache_Exception_UnknownFilterException extends UnexpectedValueException
     protected $filterName;
 
     /**
-     * @param string $filterName
+     * @param string    $filterName
+     * @param Exception $previous
      */
-    public function __construct($filterName)
+    public function __construct($filterName, Exception $previous = null)
     {
         $this->filterName = $filterName;
-        parent::__construct(sprintf('Unknown filter: %s', $filterName));
+        $message = sprintf('Unknown filter: %s', $filterName);
+        if (method_exists(__CLASS__, 'getPrevious')) {
+            parent::__construct($message, 0, $previous);
+        } else {
+            parent::__construct($message);
+        }
     }
 
     public function getFilterName()

--- a/src/Mustache/Exception/UnknownHelperException.php
+++ b/src/Mustache/Exception/UnknownHelperException.php
@@ -17,12 +17,18 @@ class Mustache_Exception_UnknownHelperException extends InvalidArgumentException
     protected $helperName;
 
     /**
-     * @param string $helperName
+     * @param string    $helperName
+     * @param Exception $previous
      */
-    public function __construct($helperName)
+    public function __construct($helperName, Exception $previous = null)
     {
         $this->helperName = $helperName;
-        parent::__construct(sprintf('Unknown helper: %s', $helperName));
+        $message = sprintf('Unknown helper: %s', $helperName);
+        if (method_exists(__CLASS__, 'getPrevious')) {
+            parent::__construct($message, 0, $previous);
+        } else {
+            parent::__construct($message);
+        }
     }
 
     public function getHelperName()

--- a/src/Mustache/Exception/UnknownTemplateException.php
+++ b/src/Mustache/Exception/UnknownTemplateException.php
@@ -17,12 +17,18 @@ class Mustache_Exception_UnknownTemplateException extends InvalidArgumentExcepti
     protected $templateName;
 
     /**
-     * @param string $templateName
+     * @param string    $templateName
+     * @param Exception $previous
      */
-    public function __construct($templateName)
+    public function __construct($templateName, Exception $previous = null)
     {
         $this->templateName = $templateName;
-        parent::__construct(sprintf('Unknown template: %s', $templateName));
+        $message = sprintf('Unknown template: %s', $templateName);
+        if (method_exists(__CLASS__, 'getPrevious')) {
+            parent::__construct($message, 0, $previous);
+        } else {
+            parent::__construct($message);
+        }
     }
 
     public function getTemplateName()

--- a/test/Mustache/Test/Exception/UnknownFilterExceptionTest.php
+++ b/test/Mustache/Test/Exception/UnknownFilterExceptionTest.php
@@ -29,4 +29,16 @@ class Mustache_Test_Exception_UnknownFilterExceptionTest extends PHPUnit_Framewo
         $e = new Mustache_Exception_UnknownFilterException('eggs');
         $this->assertEquals('eggs', $e->getFilterName());
     }
+
+    public function testPrevious()
+    {
+        if (!method_exists('Exception', 'getPrevious')) {
+            $this->markTestSkipped('Exception chaining requires at least PHP 5.3');
+        }
+
+        $previous = new Exception();
+        $e = new Mustache_Exception_UnknownFilterException('foo', $previous);
+
+        $this->assertSame($previous, $e->getPrevious());
+    }
 }

--- a/test/Mustache/Test/Exception/UnknownHelperExceptionTest.php
+++ b/test/Mustache/Test/Exception/UnknownHelperExceptionTest.php
@@ -29,4 +29,15 @@ class Mustache_Test_Exception_UnknownHelperExceptionTest extends PHPUnit_Framewo
         $e = new Mustache_Exception_UnknownHelperException('gamma');
         $this->assertEquals('gamma', $e->getHelperName());
     }
+
+    public function testPrevious()
+    {
+        if (!method_exists('Exception', 'getPrevious')) {
+            $this->markTestSkipped('Exception chaining requires at least PHP 5.3');
+        }
+
+        $previous = new Exception();
+        $e = new Mustache_Exception_UnknownHelperException('foo', $previous);
+        $this->assertSame($previous, $e->getPrevious());
+    }
 }

--- a/test/Mustache/Test/Exception/UnknownTemplateExceptionTest.php
+++ b/test/Mustache/Test/Exception/UnknownTemplateExceptionTest.php
@@ -29,4 +29,15 @@ class Mustache_Test_Exception_UnknownTemplateExceptionTest extends PHPUnit_Frame
         $e = new Mustache_Exception_UnknownTemplateException('yoshi');
         $this->assertEquals('yoshi', $e->getTemplateName());
     }
+
+    public function testPrevious()
+    {
+        if (!method_exists('Exception', 'getPrevious')) {
+            $this->markTestSkipped('Exception chaining requires at least PHP 5.3');
+        }
+
+        $previous = new Exception();
+        $e = new Mustache_Exception_UnknownTemplateException('foo', $previous);
+        $this->assertSame($previous, $e->getPrevious());
+    }
 }


### PR DESCRIPTION
I've wanted to add a previous exception to `UnknownTemplateException`, but all of the local exceptions don't allow chaining. This adds it.

~~(I _think_ the PHP 5.2 build will fail with an unrecognised parameter, but I'll wait on Travis to confirm.)~~