### PR TITLE
Correct Mustache_Context::findInBlock when nested blocks with same parameter names exists

### DIFF
--- a/src/Mustache/Context.php
+++ b/src/Mustache/Context.php
@@ -186,7 +186,8 @@ class Mustache_Context
      */
     public function findInBlock($id)
     {
-        foreach ($this->blockStack as $context) {
+        for ($i = count($this->blockStack) - 1; $i >= 0; $i--) {
+            $context = &$this->blockStack[$i];
             if (array_key_exists($id, $context)) {
                 return $context[$id];
             }


### PR DESCRIPTION
Modify Mustache_Context::findInBlock to check blockStack in reverse order to ensure the inner block declaration is used when multiple blocks are declared with the same name at different levels.

It's more comprehensible that way and mimics the context resolution behavior.

this correct issue #275