### PR TITLE
Allow multiple "baseDir" (array) to search for templates.

### DIFF
--- a/test/Mustache/Test/Loader/FilesystemLoaderTest.php
+++ b/test/Mustache/Test/Loader/FilesystemLoaderTest.php
@@ -29,6 +29,18 @@ class Mustache_Test_Loader_FilesystemLoaderTest extends PHPUnit_Framework_TestCa
         $this->assertEquals('one contents', $loader->load('one'));
     }
 
+    public function testConstructorWithMultipleDirs()
+    {
+        $baseDir = array(
+            realpath(dirname(__FILE__) . '/../../../fixtures/templates'),
+            realpath(dirname(__FILE__) . '/../../../fixtures/more_templates'),
+        );
+        $loader = new Mustache_Loader_FilesystemLoader($baseDir, array('extension' => '.ms'));
+        $this->assertEquals('alpha contents', $loader->load('alpha'));
+        $this->assertEquals('beta contents', $loader->load('beta.ms'));
+        $this->assertEquals('gamma contents', $loader->load('gamma.ms'));
+    }
+
     public function testConstructorWithProtocol()
     {
         $baseDir = realpath(dirname(__FILE__) . '/../../../fixtures/templates');

--- a/test/fixtures/more_templates/gamma.ms
+++ b/test/fixtures/more_templates/gamma.ms
@@ -1,0 +1,1 @@
+gamma contents

--- a/test/fixtures/more_templates/three.ms
+++ b/test/fixtures/more_templates/three.ms
@@ -1,0 +1,1 @@
+three contents


### PR DESCRIPTION
This change allows FileSystemLoader to use an array as “baseDir”. When
loading a template, all directories will be searched into, the first one
matching the given file will be returned.

It is backward-compatible; passing a string as baseDir still works as intended.

Also included: Unit tests.