### PR TITLE
Allow rendering source directly (without going through a loader)

### DIFF
--- a/src/Mustache/Engine.php
+++ b/src/Mustache/Engine.php
@@ -220,6 +220,22 @@ class Mustache_Engine
     }
 
     /**
+     * Render a source directly (without loader).
+     *
+     * @see Mustache_Engine::loadSource
+     * @see Mustache_Template::render
+     *
+     * @param string $source
+     * @param mixed $context  (default: array())
+     *
+     * @return string Rendered template
+     */
+    public function renderSource($source, $context = array())
+    {
+        return $this->loadSource($source)->render($context);;
+    }
+
+    /**
      * Get the current Mustache escape callback.
      *
      * @return callable|null

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -81,6 +81,17 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         $this->assertEquals($source, $mustache->source);
     }
 
+    public function testRenderSource()
+    {
+        $source = 'Hello {{ foo }}!';
+        $data = array('foo' => 'World');
+
+        $mustache = new Mustache_Engine();
+        $ret =$mustache->renderSource($source, $data);
+        $this->assertEquals('Hello World!', $ret);
+
+    }
+
     public function testSettingServices()
     {
         $logger    = new Mustache_Logger_StreamLogger(tmpfile());


### PR DESCRIPTION
This PR allows to render a "source" (or "template string") directly, without having to go through a loader. This allows to use a loader such as a `FileSystemLoader` without having to chain it with a `StringLoader` to use template source (or string) directly.

It still goes through the cache process (through the private `loadSource()` method).