### PR TITLE
Making properties protected rather than private

### DIFF
--- a/src/Mustache/Loader/FilesystemLoader.php
+++ b/src/Mustache/Loader/FilesystemLoader.php
@@ -26,9 +26,9 @@
  */
 class Mustache_Loader_FilesystemLoader implements Mustache_Loader
 {
-    private $baseDir;
-    private $extension = '.mustache';
-    private $templates = array();
+    protected $baseDir;
+    protected $extension = '.mustache';
+    protected $templates = array();
 
     /**
      * Mustache filesystem Loader constructor.


### PR DESCRIPTION
Just a simple change. I'm making a fuzzy pattern loader compatible with PatternLab mustache templates. I don't need to make massive changes so want to extend `Mustache_Loader_FilesystemLoader`, annoyingly the variables I need to access are private which isn't great for extending. 