### PR TITLE
Introduce a strict_variables option to the Engine

### DIFF
--- a/src/Mustache/Context.php
+++ b/src/Mustache/Context.php
@@ -14,19 +14,22 @@
  */
 class Mustache_Context
 {
-    private $stack      = array();
-    private $blockStack = array();
+    private $stack           = array();
+    private $blockStack      = array();
+    private $strictVariables;
 
     /**
      * Mustache rendering Context constructor.
      *
      * @param mixed $context Default rendering context (default: null)
+     * @param bool $strictVariables
      */
-    public function __construct($context = null)
+    public function __construct($context = null, $strictVariables = false)
     {
         if ($context !== null) {
             $this->stack = array($context);
         }
+        $this->strictVariables = $strictVariables;
     }
 
     /**
@@ -200,10 +203,11 @@ class Mustache_Context
      *
      * @see Mustache_Context::find
      *
-     * @param string $id    Variable name
-     * @param array  $stack Context stack
+     * @param string $id Variable name
+     * @param array $stack Context stack
      *
      * @return mixed Variable value, or '' if not found
+     * @throws \Mustache_Exception_UnknownVariableException
      */
     private function findVariableInStack($id, array $stack)
     {
@@ -237,6 +241,9 @@ class Mustache_Context
             }
         }
 
+        if ($this->strictVariables) {
+            throw new Mustache_Exception_UnknownVariableException($id);
+        }
         return '';
     }
 }

--- a/src/Mustache/Engine.php
+++ b/src/Mustache/Engine.php
@@ -55,6 +55,7 @@ class Mustache_Engine
     private $charset = 'UTF-8';
     private $logger;
     private $strictCallables = false;
+    private $strictVariables = false;
     private $pragmas = array();
     private $delimiters;
 
@@ -132,6 +133,9 @@ class Mustache_Engine
      *         // This currently defaults to false, but will default to true in v3.0.
      *         'strict_callables' => true,
      *
+     *         // Treat unknown variables as a failure and throw an exception instead of silently ignoring them.
+     *         'strict_variables' => true,
+     *
      *         // Enable pragmas across all templates, regardless of the presence of pragma tags in the individual
      *         // templates.
      *         'pragmas' => [Mustache_Engine::PRAGMA_FILTERS],
@@ -204,6 +208,10 @@ class Mustache_Engine
 
         if (isset($options['strict_callables'])) {
             $this->strictCallables = $options['strict_callables'];
+        }
+
+        if (isset($options['strict_variables'])) {
+            $this->strictVariables = $options['strict_variables'];
         }
 
         if (isset($options['delimiters'])) {
@@ -812,7 +820,7 @@ class Mustache_Engine
         $compiler = $this->getCompiler();
         $compiler->setPragmas($this->getPragmas());
 
-        return $compiler->compile($source, $tree, $name, isset($this->escape), $this->charset, $this->strictCallables, $this->entityFlags);
+        return $compiler->compile($source, $tree, $name, isset($this->escape), $this->charset, $this->strictCallables, $this->entityFlags, $this->strictVariables);
     }
 
     /**

--- a/src/Mustache/Exception/UnknownVariableException.php
+++ b/src/Mustache/Exception/UnknownVariableException.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Mustache.php.
+ *
+ * (c) 2017 Enalean
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Mustache_Exception_UnknownVariableException extends UnexpectedValueException implements Mustache_Exception
+{
+    /**
+     * @var string
+     */
+    protected $variableName;
+
+    /**
+     * @param string    $variableName
+     * @param Exception $previous
+     */
+    public function __construct($variableName, Exception $previous = null)
+    {
+        $this->variableName = $variableName;
+        $message = sprintf('Unknown variable: %s', $variableName);
+        if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
+            parent::__construct($message, 0, $previous);
+        } else {
+            parent::__construct($message); // @codeCoverageIgnore
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getVariableName()
+    {
+        return $this->variableName;
+    }
+}

--- a/src/Mustache/Template.php
+++ b/src/Mustache/Template.php
@@ -27,6 +27,11 @@ abstract class Mustache_Template
     protected $strictCallables = false;
 
     /**
+     * @var bool
+     */
+    protected $strictVariables = false;
+
+    /**
      * Mustache Template constructor.
      *
      * @param Mustache_Engine $mustache
@@ -143,7 +148,7 @@ abstract class Mustache_Template
      */
     protected function prepareContextStack($context = null)
     {
-        $stack = new Mustache_Context();
+        $stack = new Mustache_Context(null, $this->strictVariables);
 
         $helpers = $this->mustache->getHelpers();
         if (!$helpers->isEmpty()) {

--- a/test/Mustache/Test/CompilerTest.php
+++ b/test/Mustache/Test/CompilerTest.php
@@ -21,7 +21,7 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
     {
         $compiler = new Mustache_Compiler();
 
-        $compiled = $compiler->compile($source, $tree, $name, $customEscaper, $charset, false, $entityFlags);
+        $compiled = $compiler->compile($source, $tree, $name, $customEscaper, $charset, false, $entityFlags, false);
         foreach ($expected as $contains) {
             $this->assertContains($contains, $compiled);
         }

--- a/test/Mustache/Test/ContextTest.php
+++ b/test/Mustache/Test/ContextTest.php
@@ -180,6 +180,29 @@ class Mustache_Test_ContextTest extends PHPUnit_Framework_TestCase
         $context->push(array('a' => 1));
         $context->findAnchoredDot('a');
     }
+
+    /**
+     * @expectedException Mustache_Exception_UnknownVariableException
+     */
+    public function testUnknownVariableThrowsException()
+    {
+        $context = new Mustache_Context(null, true);
+        $context->push(array('a' => 1));
+        $context->find('b');
+    }
+
+    /**
+     * @expectedException Mustache_Exception_UnknownVariableException
+     */
+    public function testAnchoredDotNotationUnknownVariableThrowsException()
+    {
+        $context = new Mustache_Context(null, true);
+        $a = array(
+            'a' => array('b' => 1),
+        );
+        $context->push($a);
+        $context->find('a.c');
+    }
 }
 
 class Mustache_Test_TestDummy

--- a/test/Mustache/Test/Exception/UnknownVariableExceptionTest.php
+++ b/test/Mustache/Test/Exception/UnknownVariableExceptionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Mustache.php.
+ *
+ * (c) 2017 Enalean
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Mustache_Test_Exception_UnknownVariableExceptionTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testInstance()
+    {
+        $e = new Mustache_Exception_UnknownVariableException('alpha');
+        $this->assertTrue($e instanceof UnexpectedValueException);
+        $this->assertTrue($e instanceof Mustache_Exception);
+    }
+
+    public function testMessage()
+    {
+        $e = new Mustache_Exception_UnknownVariableException('beta');
+        $this->assertEquals('Unknown variable: beta', $e->getMessage());
+    }
+
+    public function testGetHelperName()
+    {
+        $e = new Mustache_Exception_UnknownVariableException('gamma');
+        $this->assertEquals('gamma', $e->getVariableName());
+    }
+
+    public function testPrevious()
+    {
+        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+            $this->markTestSkipped('Exception chaining requires at least PHP 5.3');
+        }
+
+        $previous = new Exception();
+        $e = new Mustache_Exception_UnknownVariableException('foo', $previous);
+        $this->assertSame($previous, $e->getPrevious());
+    }
+}

--- a/test/Mustache/Test/Functional/StrictVariablesTest.php
+++ b/test/Mustache/Test/Functional/StrictVariablesTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Mustache.php.
+ *
+ * (c) 2017 Enalean
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @group lambdas
+ * @group functional
+ */
+class Mustache_Test_Functional_StrictVariablesTest extends PHPUnit_Framework_TestCase
+{
+    private $mustache;
+
+    public function setUp()
+    {
+        $this->mustache = new Mustache_Engine(array('strict_variables' => true));
+    }
+
+    /**
+     * @@dataProvider strictVariablesProvider
+     */
+    public function testStrictVariables($template, $expected)
+    {
+        $context = array(
+            'a' => array('b' => 'ab'),
+            'c' => 'c',
+            'd' => 'd',
+        );
+
+        $tpl = $this->mustache->loadTemplate($template);
+        $this->assertEquals($expected, $tpl->render($context));
+    }
+
+    public function strictVariablesProvider()
+    {
+        return array(
+            array('{{ c }}', 'c'),
+            array('{{# a }}{{ b }}{{/ a }}', 'ab'),
+            array('{{ a.b }}', 'ab'),
+            array('{{# c }}{{ d }}{{/ c }}', 'd'),
+            array('{{# x }}{{/ x }}', ''),
+            array('{{^ x }}{{/ x }}', ''),
+            array('{{# a }}{{# x }}{{/ x }}{{/ a }}', ''),
+            array('{{# a.x }}{{/ a.x }}', ''),
+            array('{{# d.x }}{{/ d.x }}', ''),
+            array('{{^ a }}{{ x }}{{/ a }}', ''),
+            array('{{# f }}{{ x }}{{/ f }}', ''),
+        );
+    }
+
+
+
+    /**
+     * @dataProvider unknownVariableThrowsExceptionProvider
+     * @expectedException Mustache_Exception_UnknownVariableException
+     */
+    public function testUnknownVariableThrowsException($template)
+    {
+        $context = array(
+            'a' => array('b' => 1),
+            'c' => 1,
+            'd' => 0,
+        );
+
+        $tpl = $this->mustache->loadTemplate($template);
+        $tpl->render($context);
+    }
+
+    public function unknownVariableThrowsExceptionProvider()
+    {
+        return array(
+            array('{{ e }}'),
+            array('{{ .a }}'),
+            array('{{ .a.b }}'),
+            array('{{ a.c }}')
+        );
+    }
+}


### PR DESCRIPTION
When the strict_variables option is enabled, any encountered
unknown variables throw an UnknownVariableException.

This option is useful in a development/CI environnement to catch
mistakes in templates early instead of silently returning an empty string.

This kind of behavior in case of a variable "miss" is accepted by the
mustache manual [1].

[1] https://mustache.github.io/mustache.5.html#Variables