### PR TITLE
(chore) Fix the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ sudo: false
 matrix:
   include:
     - php: 5.2
+      dist: precise
     - php: 5.3
+      dist: precise
     - php: 5.4
     - php: 5.5
     - php: 5.6


### PR DESCRIPTION
This fixes the Travis build since PHP 5.2 and 5.3 are only supported on Ubuntu Precise. EOL of Precise support is April 2018 I believe.

https://blog.travis-ci.com/2017-08-31-trusty-as-default-status
