### PR TITLE
Run tests against PHP 7.2 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - php: 5.6
     - php: 7.0
     - php: 7.1
+    - php: 7.2
     - php: hhvm
       dist: trusty
 


### PR DESCRIPTION
PHP 7.2 has been released as a stable version [1]

[1] https://secure.php.net/archive/2017.php#id2017-11-30-1