### PR TITLE
Adjusted log level argument type

### DIFF
--- a/src/Mustache/Cache/AbstractCache.php
+++ b/src/Mustache/Cache/AbstractCache.php
@@ -47,7 +47,7 @@ abstract class Mustache_Cache_AbstractCache implements Mustache_Cache
     /**
      * Add a log record if logging is enabled.
      *
-     * @param int    $level   The logging level
+     * @param string $level   The logging level
      * @param string $message The log message
      * @param array  $context The log context
      */


### PR DESCRIPTION
Log `$level` is documented to accept `int`, but the actual code passes `string` constants. For the record upstream PSR interface declares `mixed`.

Small thing, but static code analysis catches type mismatch for me downstream. :)