### PR TITLE
Handle $parent being null in checkIfTokenIsAllowedInParent

### DIFF
--- a/src/Mustache/Parser.php
+++ b/src/Mustache/Parser.php
@@ -275,6 +275,9 @@ class Mustache_Parser
      */
     private function checkIfTokenIsAllowedInParent($parent, array $token)
     {
+        if (empty($parent[Mustache_Tokenizer::TYPE])) {
+            return;
+        }
         if ($parent[Mustache_Tokenizer::TYPE] === Mustache_Tokenizer::T_PARENT) {
             throw new Mustache_Exception_SyntaxException('Illegal content in < parent tag', $token);
         }


### PR DESCRIPTION
Fixes an issue with PHP 7.4. If $parent is null, or the item in the $parent array does not exist, then it won't fail