### PR TITLE
Fix one more php74 notice

### DIFF
--- a/src/Mustache/Parser.php
+++ b/src/Mustache/Parser.php
@@ -149,7 +149,7 @@ class Mustache_Parser
                 case Mustache_Tokenizer::T_BLOCK_VAR:
                     if ($this->pragmaBlocks) {
                         // BLOCKS pragma is enabled, let's do this!
-                        if ($parent[Mustache_Tokenizer::TYPE] === Mustache_Tokenizer::T_PARENT) {
+                        if (is_array($parent) && $parent[Mustache_Tokenizer::TYPE] === Mustache_Tokenizer::T_PARENT) {
                             $token[Mustache_Tokenizer::TYPE] = Mustache_Tokenizer::T_BLOCK_ARG;
                         }
                         $this->clearStandaloneLines($nodes, $tokens);


### PR DESCRIPTION
Surely we also can use !empty() is isset() bus as far
as this is explicitly about arrays I decided to use that check.

Note this sums on #349 that also is 100% needed.

> Trying to use values of type null, bool, int, float or resource as an  
array (such as $null["key"]) will now generate a notice. This does not  
affect array accesses performed by list().  
RFC: https://wiki.php.net/rfc/notice-for-non-valid-array-container