### PR TITLE
Check if the array key exist first for compatibility with PHP 7.4

### DIFF
--- a/src/Mustache/Parser.php
+++ b/src/Mustache/Parser.php
@@ -149,7 +149,7 @@ class Mustache_Parser
                 case Mustache_Tokenizer::T_BLOCK_VAR:
                     if ($this->pragmaBlocks) {
                         // BLOCKS pragma is enabled, let's do this!
-                        if (isset($parent) && $parent[Mustache_Tokenizer::TYPE] === Mustache_Tokenizer::T_PARENT) {
+                        if (isset($parent[Mustache_Tokenizer::TYPE]) && $parent[Mustache_Tokenizer::TYPE] === Mustache_Tokenizer::T_PARENT) {
                             $token[Mustache_Tokenizer::TYPE] = Mustache_Tokenizer::T_BLOCK_ARG;
                         }
                         $this->clearStandaloneLines($nodes, $tokens);


### PR DESCRIPTION
During some tests using PHP 7.4, I found a warring notice like this:
`PHP Notice:  Trying to access array offset on value of type null in /root/workspace/easyengine-74/vendor/mustache/mustache/src/Mustache/Parser.php on line 278`
To fix this, I add a check for the key.