### PR TITLE
Avoid using trim() on null

### DIFF
--- a/src/Mustache/Tokenizer.php
+++ b/src/Mustache/Tokenizer.php
@@ -107,7 +107,7 @@ class Mustache_Tokenizer
 
         $this->reset();
 
-        if ($delimiters = trim($delimiters)) {
+        if (is_string($delimiters) && $delimiters = trim($delimiters)) {
             $this->setDelimiters($delimiters);
         }
 

--- a/src/Mustache/Tokenizer.php
+++ b/src/Mustache/Tokenizer.php
@@ -88,11 +88,11 @@ class Mustache_Tokenizer
      * @throws Mustache_Exception_InvalidArgumentException when $delimiters string is invalid
      *
      * @param string $text       Mustache template source to tokenize
-     * @param string $delimiters Optionally, pass initial opening and closing delimiters (default: null)
+     * @param string $delimiters Optionally, pass initial opening and closing delimiters (default: empty string)
      *
      * @return array Set of Mustache tokens
      */
-    public function scan($text, $delimiters = null)
+    public function scan($text, $delimiters = '')
     {
         // Setting mbstring.func_overload makes things *really* slow.
         // Let's do everyone a favor and scan this string as ASCII instead.

--- a/test/Mustache/Test/TokenizerTest.php
+++ b/test/Mustache/Test/TokenizerTest.php
@@ -301,6 +301,54 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
                     ),
                 ),
             ),
+
+            // Delimiters are trimmed
+            array(
+                '<% name %>',
+                ' <% %> ',
+                array(
+                    array(
+                        Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_ESCAPED,
+                        Mustache_Tokenizer::NAME  => 'name',
+                        Mustache_Tokenizer::OTAG  => '<%',
+                        Mustache_Tokenizer::CTAG  => '%>',
+                        Mustache_Tokenizer::LINE  => 0,
+                        Mustache_Tokenizer::INDEX => 10,
+                    ),
+                ),
+            ),
+
+            // An empty string makes delimiters fall back to default
+            array(
+                '{{ name }}',
+                '',
+                array(
+                    array(
+                        Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_ESCAPED,
+                        Mustache_Tokenizer::NAME  => 'name',
+                        Mustache_Tokenizer::OTAG  => '{{',
+                        Mustache_Tokenizer::CTAG  => '}}',
+                        Mustache_Tokenizer::LINE  => 0,
+                        Mustache_Tokenizer::INDEX => 10,
+                    ),
+                ),
+            ),
+
+            // A bad delimiter type makes delimiters fall back to default
+            array(
+                '{{ name }}',
+                42,
+                array(
+                    array(
+                        Mustache_Tokenizer::TYPE  => Mustache_Tokenizer::T_ESCAPED,
+                        Mustache_Tokenizer::NAME  => 'name',
+                        Mustache_Tokenizer::OTAG  => '{{',
+                        Mustache_Tokenizer::CTAG  => '}}',
+                        Mustache_Tokenizer::LINE  => 0,
+                        Mustache_Tokenizer::INDEX => 10,
+                    ),
+                ),
+            ),
         );
     }
 }


### PR DESCRIPTION
The `$delimiters` argument for the `Tokenizer::scan()` method is optional and currently defaults to `null` (which is not documented as a valid value in the docblock'.

This default value of `null` is then passed into the `trim()` function, which causes a deprecation warning starting with PHP 8.1:
```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/mustache/mustache/src/Mustache/Tokenizer.php on line 110
```

This PR changes the default value to be an empty string instead, which makes the deprecation warning go away in most cases without any further changes and is more corrected in terms o the documented argument type.

Furthermore, the PR adds a check to see if the `$delimiters` are a string before trying to trim them.

Finally, a few tests are added to ensure custom delimiter handling works as expected.