### PR TITLE
Explicit conversion to string in htmlspecialchars

### DIFF
--- a/src/Mustache/Compiler.php
+++ b/src/Mustache/Compiler.php
@@ -604,7 +604,7 @@ class Mustache_Compiler
         return preg_replace("/\n( {8})?/", "\n" . str_repeat(' ', $bonus * 4), $text);
     }
 
-    const DEFAULT_ESCAPE = 'htmlspecialchars(%s, %s, %s)';
+    const DEFAULT_ESCAPE = 'htmlspecialchars((string) %s, %s, %s)';
     const CUSTOM_ESCAPE  = 'call_user_func($this->mustache->getEscape(), %s)';
 
     /**

--- a/src/Mustache/Compiler.php
+++ b/src/Mustache/Compiler.php
@@ -604,7 +604,7 @@ class Mustache_Compiler
         return preg_replace("/\n( {8})?/", "\n" . str_repeat(' ', $bonus * 4), $text);
     }
 
-    const DEFAULT_ESCAPE = 'htmlspecialchars((string) %s, %s, %s)';
+    const DEFAULT_ESCAPE = 'htmlspecialchars(%s ?? (string) %s, %s, %s)';
     const CUSTOM_ESCAPE  = 'call_user_func($this->mustache->getEscape(), %s)';
 
     /**
@@ -620,7 +620,7 @@ class Mustache_Compiler
             return sprintf(self::CUSTOM_ESCAPE, $value);
         }
 
-        return sprintf(self::DEFAULT_ESCAPE, $value, var_export($this->entityFlags, true), var_export($this->charset, true));
+        return sprintf(self::DEFAULT_ESCAPE, $value, $value, var_export($this->entityFlags, true), var_export($this->charset, true));
     }
 
     /**


### PR DESCRIPTION
Solving PHP 8.1 deprecation warning: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated