### PR TITLE
Add option to disable lambda rendering

### DIFF
--- a/src/Mustache/Engine.php
+++ b/src/Mustache/Engine.php
@@ -53,6 +53,7 @@ class Mustache_Engine
     private $charset = 'UTF-8';
     private $logger;
     private $strictCallables = false;
+    private $disableLambdaRendering = false;
     private $pragmas = array();
     private $delimiters;
 
@@ -130,6 +131,11 @@ class Mustache_Engine
      *         // This currently defaults to false, but will default to true in v3.0.
      *         'strict_callables' => true,
      *
+     *         // Do not render the output of lambdas. Use this to prevent repeated rendering if the lambda already
+     *         // takes care of rendering its content. This helps protect against mustache code injection when user
+     *         // input is passed directly into the template. Defaults to false.
+     *         'disable_lambda_rendering' => true,
+     *
      *         // Enable pragmas across all templates, regardless of the presence of pragma tags in the individual
      *         // templates.
      *         'pragmas' => [Mustache_Engine::PRAGMA_FILTERS],
@@ -202,6 +208,10 @@ class Mustache_Engine
 
         if (isset($options['strict_callables'])) {
             $this->strictCallables = $options['strict_callables'];
+        }
+
+        if (isset($options['disable_lambda_rendering'])) {
+            $this->disableLambdaRendering = $options['disable_lambda_rendering'];
         }
 
         if (isset($options['delimiters'])) {
@@ -624,14 +634,15 @@ class Mustache_Engine
         //
         // Keep this list in alphabetical order :)
         $chunks = array(
-            'charset'         => $this->charset,
-            'delimiters'      => $this->delimiters ? $this->delimiters : '{{ }}',
-            'entityFlags'     => $this->entityFlags,
-            'escape'          => isset($this->escape) ? 'custom' : 'default',
-            'key'             => ($source instanceof Mustache_Source) ? $source->getKey() : 'source',
-            'pragmas'         => $this->getPragmas(),
-            'strictCallables' => $this->strictCallables,
-            'version'         => self::VERSION,
+            'charset'                => $this->charset,
+            'delimiters'             => $this->delimiters ? $this->delimiters : '{{ }}',
+            'entityFlags'            => $this->entityFlags,
+            'escape'                 => isset($this->escape) ? 'custom' : 'default',
+            'key'                    => ($source instanceof Mustache_Source) ? $source->getKey() : 'source',
+            'pragmas'                => $this->getPragmas(),
+            'strictCallables'        => $this->strictCallables,
+            'disableLambdaRendering' => $this->disableLambdaRendering,
+            'version'                => self::VERSION,
         );
 
         $key = json_encode($chunks);
@@ -810,7 +821,7 @@ class Mustache_Engine
         $compiler = $this->getCompiler();
         $compiler->setPragmas($this->getPragmas());
 
-        return $compiler->compile($source, $tree, $name, isset($this->escape), $this->charset, $this->strictCallables, $this->entityFlags);
+        return $compiler->compile($source, $tree, $name, isset($this->escape), $this->charset, $this->strictCallables, $this->entityFlags, $this->disableLambdaRendering);
     }
 
     /**

--- a/test/Mustache/Test/FiveThree/Functional/DisableLambdaRenderingTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/DisableLambdaRenderingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Mustache.php.
+ *
+ * (c) 2010-2017 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @group lambdas
+ * @group functional
+ */
+class Mustache_Test_FiveThree_Functional_DisableLambdaRenderingTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider callables
+     */
+    public function testDisableLambdaRendering($disable, $code, $expected)
+    {
+        $mustache = new Mustache_Engine(array('disable_lambda_rendering' => $disable));
+        $tpl      = $mustache->loadTemplate($code);
+
+        $data = new StdClass();
+        $data->name   = 'Yoshi';
+        $data->lambda = function ($tpl) {
+            return $tpl;
+        };
+
+        $this->assertEquals($expected, $tpl->render($data));
+    }
+
+    public function callables()
+    {
+        return array(
+            // Lambdas with rendering enabled
+            array(
+                false,
+                '{{# lambda }}{{ name }}{{/ lambda }}',
+                'Yoshi',
+            ),
+            array(
+                false,
+                '{{# lambda }}{{# lambda }}Test{{/ lambda }}{{/ lambda }}',
+                'Test',
+            ),
+
+            // Lambdas with rendering disabled
+            array(
+                true,
+                '{{# lambda }}{{ name }}{{/ lambda }}',
+                '{{ name }}',
+            ),
+            array(
+                true,
+                '{{# lambda }}{{# lambda }}Test{{/ lambda }}{{/ lambda }}',
+                '{{# lambda }}Test{{/ lambda }}',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
This pull request adds an option called `disable_lambda_rendering` that can be used to disable rendering of lambda return values. This is necessary to prevent repeated rendering if the lambda already takes care of rendering its own content.