### PR TITLE
Bump to PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "php": ">=5.2.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7|~4.0|~5.0",
-        "friendsofphp/php-cs-fixer": "~1.11"
+        "phpunit/phpunit": "^9",
+        "friendsofphp/php-cs-fixer": "^3"
     },
     "autoload": {
         "psr-0": { "Mustache": "src/" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" colors="true" bootstrap="./test/bootstrap.php">
-	<testsuite name="Mustache">
-		<directory suffix="Test.php">./test</directory>
-		<exclude>./test/Mustache/Test/FiveThree</exclude>
-	</testsuite>
-
-	<testsuite name="Mustache FiveThree">
-		<directory suffix="Test.php" phpVersion="5.3.0" phpVersionOperator=">=">./test/Mustache/Test/FiveThree</directory>
-	</testsuite>
-
-	<filter>
-		<whitelist>
-			<directory suffix=".php">./src/Mustache</directory>
-		</whitelist>
-	</filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" bootstrap="./test/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src/Mustache</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Mustache">
+      <directory suffix="Test.php">./test</directory>
+      <exclude>./test/Mustache/Test/FiveThree</exclude>
+    </testsuite>
+    <testsuite name="Mustache FiveThree">
+      <directory suffix="Test.php" phpVersion="5.3.0" phpVersionOperator="&gt;=">./test/Mustache/Test/FiveThree</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/test/Mustache/Test/AutoloaderTest.php
+++ b/test/Mustache/Test/AutoloaderTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_AutoloaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_AutoloaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testRegister()
     {

--- a/test/Mustache/Test/Cache/AbstractCacheTest.php
+++ b/test/Mustache/Test/Cache/AbstractCacheTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_Cache_AbstractCacheTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Cache_AbstractCacheTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetSetLogger()
     {
@@ -19,13 +19,11 @@ class Mustache_Test_Cache_AbstractCacheTest extends PHPUnit_Framework_TestCase
         $this->assertSame($logger, $cache->getLogger());
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testSetLoggerThrowsExceptions()
     {
         $cache  = new CacheStub();
         $logger = new StdClass();
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $cache->setLogger($logger);
     }
 }

--- a/test/Mustache/Test/CompilerTest.php
+++ b/test/Mustache/Test/CompilerTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_CompilerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider getCompileValues
@@ -23,7 +23,7 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
 
         $compiled = $compiler->compile($source, $tree, $name, $customEscaper, $charset, false, $entityFlags);
         foreach ($expected as $contains) {
-            $this->assertContains($contains, $compiled);
+            $this->assertStringContainsString($contains, $compiled);
         }
     }
 
@@ -132,12 +132,10 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Mustache_Exception_SyntaxException
-     */
     public function testCompilerThrowsSyntaxException()
     {
         $compiler = new Mustache_Compiler();
+        $this->expectException(Mustache_Exception_SyntaxException::class);
         $compiler->compile('', array(array(Mustache_Tokenizer::TYPE => 'invalid')), 'SomeClass');
     }
 

--- a/test/Mustache/Test/ContextTest.php
+++ b/test/Mustache/Test/ContextTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_ContextTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_ContextTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstructor()
     {
@@ -171,13 +171,11 @@ class Mustache_Test_ContextTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $context->findAnchoredDot('.child.name'));
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testAnchoredDotNotationThrowsExceptions()
     {
         $context = new Mustache_Context();
         $context->push(array('a' => 1));
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $context->findAnchoredDot('a');
     }
 }

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -43,7 +43,7 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         $this->assertSame($loader, $mustache->getLoader());
         $this->assertSame($partialsLoader, $mustache->getPartialsLoader());
         $this->assertEquals('{{ foo }}', $partialsLoader->load('foo'));
-        $this->assertContains('__whot__', $mustache->getTemplateClassName('{{ foo }}'));
+        $this->assertStringContainsString('__whot__', $mustache->getTemplateClassName('{{ foo }}'));
         $this->assertEquals('strtoupper', $mustache->getEscape());
         $this->assertEquals(ENT_QUOTES, $mustache->getEntityFlags());
         $this->assertEquals('ISO-8859-1', $mustache->getCharset());
@@ -158,22 +158,20 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         $this->assertNotSame($mustache->getCache(), $mustache->getProtectedLambdaCache());
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testEmptyTemplatePrefixThrowsException()
     {
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         new Mustache_Engine(array(
             'template_class_prefix' => '',
         ));
     }
 
     /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
      * @dataProvider getBadEscapers
      */
     public function testNonCallableEscapeThrowsException($escape)
     {
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         new Mustache_Engine(array('escape' => $escape));
     }
 
@@ -185,15 +183,13 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         );
     }
 
-    /**
-     * @expectedException Mustache_Exception_RuntimeException
-     */
     public function testImmutablePartialsLoadersThrowException()
     {
         $mustache = new Mustache_Engine(array(
             'partials_loader' => new Mustache_Loader_StringLoader(),
         ));
 
+        $this->expectException(Mustache_Exception_RuntimeException::class);
         $mustache->setPartials(array('foo' => '{{ foo }}'));
     }
 
@@ -250,21 +246,17 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         return '__' . $text . '__';
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testSetHelpersThrowsExceptions()
     {
         $mustache = new Mustache_Engine();
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $mustache->setHelpers('monkeymonkeymonkey');
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testSetLoggerThrowsExceptions()
     {
         $mustache = new Mustache_Engine();
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $mustache->setLogger(new StdClass());
     }
 
@@ -305,14 +297,14 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         $result = $mustache->render('{{> foo }}{{> bar }}{{> baz }}', array());
         $this->assertEquals('FOOBAR', $result);
 
-        $this->assertContains('WARNING: Partial not found: "baz"', file_get_contents($name));
+        $this->assertStringContainsString('WARNING: Partial not found: "baz"', file_get_contents($name));
     }
 
     public function testCacheWarningLogging()
     {
         list($name, $mustache) = $this->getLoggedMustache(Mustache_Logger::WARNING);
         $mustache->render('{{ foo }}', array('foo' => 'FOO'));
-        $this->assertContains('WARNING: Template cache disabled, evaluating', file_get_contents($name));
+        $this->assertStringContainsString('WARNING: Template cache disabled, evaluating', file_get_contents($name));
     }
 
     public function testLoggingIsNotTooAnnoying()
@@ -327,15 +319,13 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         list($name, $mustache) = $this->getLoggedMustache(Mustache_Logger::DEBUG);
         $mustache->render('{{ foo }}{{> bar }}', array('foo' => 'FOO'));
         $log = file_get_contents($name);
-        $this->assertContains('DEBUG: Instantiating template: ', $log);
-        $this->assertContains('WARNING: Partial not found: "bar"', $log);
+        $this->assertStringContainsString('DEBUG: Instantiating template: ', $log);
+        $this->assertStringContainsString('WARNING: Partial not found: "bar"', $log);
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testUnknownPragmaThrowsException()
     {
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         new Mustache_Engine(array(
             'pragmas' => array('UNKNOWN'),
         ));

--- a/test/Mustache/Test/Exception/SyntaxExceptionTest.php
+++ b/test/Mustache/Test/Exception/SyntaxExceptionTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_Exception_SyntaxExceptionTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Exception_SyntaxExceptionTest extends \PHPUnit\Framework\TestCase
 {
     public function testInstance()
     {

--- a/test/Mustache/Test/Exception/UnknownFilterExceptionTest.php
+++ b/test/Mustache/Test/Exception/UnknownFilterExceptionTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_Exception_UnknownFilterExceptionTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Exception_UnknownFilterExceptionTest extends \PHPUnit\Framework\TestCase
 {
     public function testInstance()
     {

--- a/test/Mustache/Test/Exception/UnknownHelperExceptionTest.php
+++ b/test/Mustache/Test/Exception/UnknownHelperExceptionTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_Exception_UnknownHelperExceptionTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Exception_UnknownHelperExceptionTest extends \PHPUnit\Framework\TestCase
 {
     public function testInstance()
     {

--- a/test/Mustache/Test/Exception/UnknownTemplateExceptionTest.php
+++ b/test/Mustache/Test/Exception/UnknownTemplateExceptionTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_Exception_UnknownTemplateExceptionTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Exception_UnknownTemplateExceptionTest extends \PHPUnit\Framework\TestCase
 {
     public function testInstance()
     {

--- a/test/Mustache/Test/FiveThree/Functional/ClosureQuirksTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/ClosureQuirksTest.php
@@ -13,11 +13,11 @@
  * @group lambdas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_ClosureQuirksTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_ClosureQuirksTest extends \PHPUnit\Framework\TestCase
 {
     private $mustache;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/FiveThree/Functional/EngineTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/EngineTest.php
@@ -13,7 +13,7 @@
  * @group pragmas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_EngineTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_EngineTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider pragmaData

--- a/test/Mustache/Test/FiveThree/Functional/FiltersTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/FiltersTest.php
@@ -13,11 +13,11 @@
  * @group filters
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_FiltersTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_FiltersTest extends \PHPUnit\Framework\TestCase
 {
     private $mustache;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mustache = new Mustache_Engine();
     }
@@ -128,11 +128,11 @@ EOS;
     }
 
     /**
-     * @expectedException Mustache_Exception_UnknownFilterException
      * @dataProvider brokenPipeData
      */
     public function testThrowsExceptionForBrokenPipes($tpl, $data)
     {
+        $this->expectException(Mustache_Exception_UnknownFilterException::class);
         $this->mustache->render($tpl, $data);
     }
 

--- a/test/Mustache/Test/FiveThree/Functional/HigherOrderSectionsTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/HigherOrderSectionsTest.php
@@ -13,11 +13,11 @@
  * @group lambdas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_HigherOrderSectionsTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_HigherOrderSectionsTest extends \PHPUnit\Framework\TestCase
 {
     private $mustache;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/FiveThree/Functional/LambdaHelperTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/LambdaHelperTest.php
@@ -13,11 +13,11 @@
  * @group lambdas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_LambdaHelperTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_LambdaHelperTest extends \PHPUnit\Framework\TestCase
 {
     private $mustache;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/FiveThree/Functional/MustacheSpecTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/MustacheSpecTest.php
@@ -26,6 +26,7 @@ class Mustache_Test_FiveThree_Functional_MustacheSpecTest extends Mustache_Test_
         if (!file_exists(dirname(__FILE__) . '/../../../../../vendor/spec/specs/')) {
             $this->markTestSkipped('Mustache spec submodule not initialized: run "git submodule update --init"');
         }
+        $this->assertTrue(true);
     }
 
     /**

--- a/test/Mustache/Test/FiveThree/Functional/PartialLambdaIndentTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/PartialLambdaIndentTest.php
@@ -13,7 +13,7 @@
  * @group lambdas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_PartialLambdaIndentTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_PartialLambdaIndentTest extends \PHPUnit\Framework\TestCase
 {
     public function testLambdasInsidePartialsAreIndentedProperly()
     {

--- a/test/Mustache/Test/FiveThree/Functional/StrictCallablesTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/StrictCallablesTest.php
@@ -13,7 +13,7 @@
  * @group lambdas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_StrictCallablesTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_StrictCallablesTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider callables

--- a/test/Mustache/Test/Functional/CallTest.php
+++ b/test/Mustache/Test/Functional/CallTest.php
@@ -13,7 +13,7 @@
  * @group magic_methods
  * @group functional
  */
-class Mustache_Test_Functional_CallTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_CallTest extends \PHPUnit\Framework\TestCase
 {
     public function testCallEatsContext()
     {

--- a/test/Mustache/Test/Functional/ExamplesTest.php
+++ b/test/Mustache/Test/Functional/ExamplesTest.php
@@ -13,7 +13,7 @@
  * @group examples
  * @group functional
  */
-class Mustache_Test_Functional_ExamplesTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_ExamplesTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test everything in the `examples` directory.

--- a/test/Mustache/Test/Functional/HigherOrderSectionsTest.php
+++ b/test/Mustache/Test/Functional/HigherOrderSectionsTest.php
@@ -17,7 +17,7 @@ class Mustache_Test_Functional_HigherOrderSectionsTest extends Mustache_Test_Fun
 {
     private $mustache;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mustache = new Mustache_Engine();
     }
@@ -75,7 +75,9 @@ class Mustache_Test_Functional_HigherOrderSectionsTest extends Mustache_Test_Fun
 
     public function testPassthroughOptimization()
     {
-        $mustache = $this->getMock('Mustache_Engine', array('loadLambda'));
+        $mustache = $this->getMockBuilder(Mustache_Engine::class)
+            ->onlyMethods(['loadLambda'])
+            ->getMock();
         $mustache->expects($this->never())
             ->method('loadLambda');
 
@@ -89,7 +91,9 @@ class Mustache_Test_Functional_HigherOrderSectionsTest extends Mustache_Test_Fun
 
     public function testWithoutPassthroughOptimization()
     {
-        $mustache = $this->getMock('Mustache_Engine', array('loadLambda'));
+        $mustache = $this->getMockBuilder(Mustache_Engine::class)
+            ->onlyMethods(['loadLambda'])
+            ->getMock();
         $mustache->expects($this->once())
             ->method('loadLambda')
             ->will($this->returnValue($mustache->loadTemplate('<em>{{ name }}</em>')));

--- a/test/Mustache/Test/Functional/InheritanceTest.php
+++ b/test/Mustache/Test/Functional/InheritanceTest.php
@@ -13,11 +13,11 @@
  * @group inheritance
  * @group functional
  */
-class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_InheritanceTest extends \PHPUnit\Framework\TestCase
 {
     private $mustache;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mustache = new Mustache_Engine(array(
             'pragmas' => array(Mustache_Engine::PRAGMA_BLOCKS),
@@ -521,11 +521,12 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
 
     /**
      * @dataProvider getIllegalInheritanceExamples
-     * @expectedException Mustache_Exception_SyntaxException
-     * @expectedExceptionMessage Illegal content in < parent tag
      */
     public function testIllegalInheritanceExamples($partials, $data, $template)
     {
+        $this->expectException(Mustache_Exception_SyntaxException::class);
+        $this->expectExceptionMessage("Illegal content in < parent tag");
+
         $this->mustache->setPartials($partials);
         $tpl = $this->mustache->loadTemplate($template);
         $tpl->render($data);

--- a/test/Mustache/Test/Functional/MustacheInheritanceSpecTest.php
+++ b/test/Mustache/Test/Functional/MustacheInheritanceSpecTest.php
@@ -17,7 +17,7 @@
  */
 class Mustache_Test_Functional_MustacheInheritanceSpecTest extends Mustache_Test_SpecTestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$mustache = new Mustache_Engine(array(
           'pragmas' => array(Mustache_Engine::PRAGMA_BLOCKS),
@@ -33,6 +33,7 @@ class Mustache_Test_Functional_MustacheInheritanceSpecTest extends Mustache_Test
         if (!file_exists(dirname(__FILE__) . '/../../../../vendor/spec/specs/')) {
             $this->markTestSkipped('Mustache spec submodule not initialized: run "git submodule update --init"');
         }
+        $this->assertTrue(true);
     }
 
     /**

--- a/test/Mustache/Test/Functional/MustacheInjectionTest.php
+++ b/test/Mustache/Test/Functional/MustacheInjectionTest.php
@@ -13,11 +13,11 @@
  * @group mustache_injection
  * @group functional
  */
-class Mustache_Test_Functional_MustacheInjectionTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_MustacheInjectionTest extends \PHPUnit\Framework\TestCase
 {
     private $mustache;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/Functional/MustacheSpecTest.php
+++ b/test/Mustache/Test/Functional/MustacheSpecTest.php
@@ -23,9 +23,10 @@ class Mustache_Test_Functional_MustacheSpecTest extends Mustache_Test_SpecTestCa
      */
     public function testSpecInitialized()
     {
-        if (!file_exists(dirname(__FILE__) . '/../../../../vendor/spec/specs/')) {
+        if (!file_exists(__DIR__ . '/../../../../vendor/spec/specs/')) {
             $this->markTestSkipped('Mustache spec submodule not initialized: run "git submodule update --init"');
         }
+        $this->assertTrue(true);
     }
 
     /**

--- a/test/Mustache/Test/Functional/NestedPartialIndentTest.php
+++ b/test/Mustache/Test/Functional/NestedPartialIndentTest.php
@@ -13,7 +13,7 @@
  * @group functional
  * @group partials
  */
-class Mustache_Test_Functional_NestedPartialIndentTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_NestedPartialIndentTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider partialsAndStuff

--- a/test/Mustache/Test/Functional/ObjectSectionTest.php
+++ b/test/Mustache/Test/Functional/ObjectSectionTest.php
@@ -13,11 +13,11 @@
  * @group sections
  * @group functional
  */
-class Mustache_Test_Functional_ObjectSectionTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_ObjectSectionTest extends \PHPUnit\Framework\TestCase
 {
     private $mustache;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/FunctionalTestCase.php
+++ b/test/Mustache/Test/FunctionalTestCase.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-abstract class Mustache_Test_FunctionalTestCase extends PHPUnit_Framework_TestCase
+abstract class Mustache_Test_FunctionalTestCase extends \PHPUnit\Framework\TestCase
 {
     protected static $tempDir;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$tempDir = sys_get_temp_dir() . '/mustache_test';
         if (file_exists(self::$tempDir)) {

--- a/test/Mustache/Test/HelperCollectionTest.php
+++ b/test/Mustache/Test/HelperCollectionTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_HelperCollectionTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_HelperCollectionTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstructor()
     {
@@ -96,7 +96,7 @@ class Mustache_Test_HelperCollectionTest extends PHPUnit_Framework_TestCase
     public function testHelperCollectionIsntAfraidToThrowExceptions($helpers = array(), $actions = array(), $exception = null)
     {
         if ($exception) {
-            $this->setExpectedException($exception);
+            $this->expectException($exception);
         }
 
         $helpers = new Mustache_HelperCollection($helpers);
@@ -104,6 +104,7 @@ class Mustache_Test_HelperCollectionTest extends PHPUnit_Framework_TestCase
         foreach ($actions as $method => $args) {
             call_user_func_array(array($helpers, $method), $args);
         }
+        $this->assertTrue(true);
     }
 
     public function getInvalidHelperArguments()

--- a/test/Mustache/Test/Loader/ArrayLoaderTest.php
+++ b/test/Mustache/Test/Loader/ArrayLoaderTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_Loader_ArrayLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_ArrayLoaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstructor()
     {
@@ -41,11 +41,9 @@ class Mustache_Test_Loader_ArrayLoaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('BAZ', $loader->load('baz'));
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownTemplateException
-     */
     public function testMissingTemplatesThrowExceptions()
     {
+        $this->expectException(Mustache_Exception_UnknownTemplateException::class);
         $loader = new Mustache_Loader_ArrayLoader();
         $loader->load('not_a_real_template');
     }

--- a/test/Mustache/Test/Loader/CascadingLoaderTest.php
+++ b/test/Mustache/Test/Loader/CascadingLoaderTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_Loader_CascadingLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_CascadingLoaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testLoadTemplates()
     {
@@ -25,11 +25,10 @@ class Mustache_Test_Loader_CascadingLoaderTest extends PHPUnit_Framework_TestCas
         $this->assertEquals('{{#bar}}BAR{{/bar}}', $loader->load('bar'));
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownTemplateException
-     */
     public function testMissingTemplatesThrowExceptions()
     {
+        $this->expectException(Mustache_Exception_UnknownTemplateException::class);
+
         $loader = new Mustache_Loader_CascadingLoader(array(
             new Mustache_Loader_ArrayLoader(array('foo' => '{{ foo }}')),
             new Mustache_Loader_ArrayLoader(array('bar' => '{{#bar}}BAR{{/bar}}')),

--- a/test/Mustache/Test/Loader/FilesystemLoaderTest.php
+++ b/test/Mustache/Test/Loader/FilesystemLoaderTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_Loader_FilesystemLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_FilesystemLoaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstructor()
     {
@@ -59,22 +59,18 @@ class Mustache_Test_Loader_FilesystemLoaderTest extends PHPUnit_Framework_TestCa
         $this->assertEquals('beta contents', $loader->load('beta.ms'));
     }
 
-    /**
-     * @expectedException Mustache_Exception_RuntimeException
-     */
     public function testMissingBaseDirThrowsException()
     {
+        $this->expectException(Mustache_Exception_RuntimeException::class);
         new Mustache_Loader_FilesystemLoader(dirname(__FILE__) . '/not_a_directory');
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownTemplateException
-     */
     public function testMissingTemplateThrowsException()
     {
         $baseDir = realpath(dirname(__FILE__) . '/../../../fixtures/templates');
         $loader = new Mustache_Loader_FilesystemLoader($baseDir);
 
+        $this->expectException(Mustache_Exception_UnknownTemplateException::class);
         $loader->load('fake');
     }
 }

--- a/test/Mustache/Test/Loader/InlineLoaderTest.php
+++ b/test/Mustache/Test/Loader/InlineLoaderTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_Loader_InlineLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_InlineLoaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testLoadTemplates()
     {
@@ -21,28 +21,22 @@ class Mustache_Test_Loader_InlineLoaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('{{#bar}}BAR{{/bar}}', $loader->load('bar'));
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownTemplateException
-     */
     public function testMissingTemplatesThrowExceptions()
     {
         $loader = new Mustache_Loader_InlineLoader(__FILE__, __COMPILER_HALT_OFFSET__);
+        $this->expectException(Mustache_Exception_UnknownTemplateException::class);
         $loader->load('not_a_real_template');
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testInvalidOffsetThrowsException()
     {
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         new Mustache_Loader_InlineLoader(__FILE__, 'notanumber');
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testInvalidFileThrowsException()
     {
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         new Mustache_Loader_InlineLoader('notarealfile', __COMPILER_HALT_OFFSET__);
     }
 }

--- a/test/Mustache/Test/Loader/ProductionFilesystemLoaderTest.php
+++ b/test/Mustache/Test/Loader/ProductionFilesystemLoaderTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_Loader_ProductionFilesystemLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_ProductionFilesystemLoaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstructor()
     {
@@ -61,22 +61,18 @@ class Mustache_Test_Loader_ProductionFilesystemLoaderTest extends PHPUnit_Framew
         $this->assertEquals('beta contents', $loader->load('beta.ms')->getSource());
     }
 
-    /**
-     * @expectedException Mustache_Exception_RuntimeException
-     */
     public function testMissingBaseDirThrowsException()
     {
+        $this->expectException(Mustache_Exception_RuntimeException::class);
         new Mustache_Loader_ProductionFilesystemLoader(dirname(__FILE__) . '/not_a_directory');
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownTemplateException
-     */
     public function testMissingTemplateThrowsException()
     {
         $baseDir = realpath(dirname(__FILE__) . '/../../../fixtures/templates');
         $loader = new Mustache_Loader_ProductionFilesystemLoader($baseDir);
 
+        $this->expectException(Mustache_Exception_UnknownTemplateException::class);
         $loader->load('fake');
     }
 

--- a/test/Mustache/Test/Loader/StringLoaderTest.php
+++ b/test/Mustache/Test/Loader/StringLoaderTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_Loader_StringLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_StringLoaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testLoadTemplates()
     {

--- a/test/Mustache/Test/Logger/AbstractLoggerTest.php
+++ b/test/Mustache/Test/Logger/AbstractLoggerTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_Logger_AbstractLoggerTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Logger_AbstractLoggerTest extends \PHPUnit\Framework\TestCase
 {
     public function testEverything()
     {

--- a/test/Mustache/Test/Logger/StreamLoggerTest.php
+++ b/test/Mustache/Test/Logger/StreamLoggerTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Logger_StreamLoggerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider acceptsStreamData
@@ -36,15 +36,13 @@ class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Mustache_Exception_LogicException
-     */
     public function testPrematurelyClosedStreamThrowsException()
     {
         $stream = tmpfile();
         $logger = new Mustache_Logger_StreamLogger($stream);
         fclose($stream);
 
+        $this->expectException(Mustache_Exception_LogicException::class);
         $logger->log(Mustache_Logger::CRITICAL, 'message');
     }
 
@@ -61,7 +59,7 @@ class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
         $result = fread($stream, 1024);
 
         if ($shouldLog) {
-            $this->assertContains('logged', $result);
+            $this->assertStringContainsString('logged', $result);
         } else {
             $this->assertEmpty($result);
         }
@@ -189,21 +187,17 @@ class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("WARNING: log this\n", $result);
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testThrowsInvalidArgumentExceptionWhenSettingUnknownLevels()
     {
         $logger = new Mustache_Logger_StreamLogger(tmpfile());
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $logger->setLevel('bacon');
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testThrowsInvalidArgumentExceptionWhenLoggingUnknownLevels()
     {
         $logger = new Mustache_Logger_StreamLogger(tmpfile());
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $logger->log('bacon', 'CODE BACON ERROR!');
     }
 }

--- a/test/Mustache/Test/ParserTest.php
+++ b/test/Mustache/Test/ParserTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_ParserTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider getTokenSets
@@ -317,11 +317,11 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider getBadParseTrees
-     * @expectedException Mustache_Exception_SyntaxException
      */
     public function testParserThrowsExceptions($tokens)
     {
         $parser = new Mustache_Parser();
+        $this->expectException(Mustache_Exception_SyntaxException::class);
         $parser->parse($tokens);
     }
 

--- a/test/Mustache/Test/Source/FilesystemSourceTest.php
+++ b/test/Mustache/Test/Source/FilesystemSourceTest.php
@@ -12,14 +12,13 @@
 /**
  * @group unit
  */
-class Mustache_Test_Source_FilesystemSourceTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Source_FilesystemSourceTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @expectedException Mustache_Exception_RuntimeException
-     */
     public function testMissingTemplateThrowsException()
     {
         $source = new Mustache_Source_FilesystemSource(dirname(__FILE__) . '/not_a_file.mustache', array('mtime'));
+
+        $this->expectException(Mustache_Exception_RuntimeException::class);
         $source->getKey();
     }
 }

--- a/test/Mustache/Test/SpecTestCase.php
+++ b/test/Mustache/Test/SpecTestCase.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-abstract class Mustache_Test_SpecTestCase extends PHPUnit_Framework_TestCase
+abstract class Mustache_Test_SpecTestCase extends \PHPUnit\Framework\TestCase
 {
     protected static $mustache;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/TemplateTest.php
+++ b/test/Mustache/Test/TemplateTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_TemplateTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_TemplateTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstructor()
     {

--- a/test/Mustache/Test/TokenizerTest.php
+++ b/test/Mustache/Test/TokenizerTest.php
@@ -12,7 +12,7 @@
 /**
  * @group unit
  */
-class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_TokenizerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider getTokens
@@ -23,24 +23,20 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
         $this->assertSame($expected, $tokenizer->scan($text, $delimiters));
     }
 
-    /**
-     * @expectedException Mustache_Exception_SyntaxException
-     */
     public function testUnevenBracesThrowExceptions()
     {
         $tokenizer = new Mustache_Tokenizer();
 
+        $this->expectException(Mustache_Exception_SyntaxException::class);
         $text = '{{{ name }}';
         $tokenizer->scan($text, null);
     }
 
-    /**
-     * @expectedException Mustache_Exception_SyntaxException
-     */
     public function testUnevenBracesWithCustomDelimiterThrowExceptions()
     {
         $tokenizer = new Mustache_Tokenizer();
 
+        $this->expectException(Mustache_Exception_SyntaxException::class);
         $text = '<%{ name %>';
         $tokenizer->scan($text, '<% %>');
     }
@@ -354,11 +350,12 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider getUnclosedTags
-     * @expectedException Mustache_Exception_SyntaxException
      */
     public function testUnclosedTagsThrowExceptions($text)
     {
         $tokenizer = new Mustache_Tokenizer();
+
+        $this->expectException(Mustache_Exception_SyntaxException::class);
         $tokenizer->scan($text, null);
     }
 


### PR DESCRIPTION
Running tests of Mustache.php on a PHP 8.1 environment requires to bump
PHPUnit to a recent version.

* Configuration file has been updated with `phpunit --migrate-configuration`
* PHPUnit_Framework_TestCase is replaced by \PHPUnit\Framework\TestCase
* `assertContains` is replaced by `assertStringContainsString`
* `@expectedException` annotation is replaced by `$this->expectException`
* `setUp()` and `setUpBeforeClass()` should match parent implementation

Note: `$this-assertTrue(true);` has been added to avoid risky tests
(tests without assertions).

`friendsofphp/php-cs-fixer` has also been bumped to its latest version
during the update process.