### PR TITLE
Return null property values instead of treating them as undefined.

### DIFF
--- a/src/Mustache/Context.php
+++ b/src/Mustache/Context.php
@@ -223,6 +223,13 @@ class Mustache_Context
                             return $frame->$id;
                         }
 
+                        if (property_exists($frame, $id)) {
+                            $rp = new \ReflectionProperty($frame, $id);
+                            if ($rp->isPublic()) {
+                                return $frame->$id;
+                            }
+                        }
+
                         if ($frame instanceof ArrayAccess && isset($frame[$id])) {
                             return $frame[$id];
                         }

--- a/test/Mustache/Test/ContextTest.php
+++ b/test/Mustache/Test/ContextTest.php
@@ -180,6 +180,40 @@ class Mustache_Test_ContextTest extends PHPUnit_Framework_TestCase
         $context->push(array('a' => 1));
         $context->findAnchoredDot('a');
     }
+
+    public function testNullArrayValueMasking()
+    {
+        $context = new Mustache_Context();
+
+        $a = array(
+            'name' => 'not null'
+        );
+        $b = array(
+            'name' => null
+        );
+
+        $context->push($a);
+        $context->push($b);
+
+        $this->assertNull($context->find('name'));
+    }
+
+    public function testNullPropertyValueMasking()
+    {
+        $context = new Mustache_Context();
+
+        $a = (object) array(
+            'name' => 'not null'
+        );
+        $b = (object) array(
+            'name' => null
+        );
+
+        $context->push($a);
+        $context->push($b);
+
+        $this->assertNull($context->find('name'));
+    }
 }
 
 class Mustache_Test_TestDummy


### PR DESCRIPTION
Return null property values instead of treating them as undefined.

Null array values already return; this change makes null property values behave the same way.  I've added unit tests for both cases.