### PR TITLE
Improve support for complex lambda values

### DIFF
--- a/src/Mustache/Compiler.php
+++ b/src/Mustache/Compiler.php
@@ -570,18 +570,23 @@ class Mustache_Compiler
         if (!(%s)) {
             throw new Mustache_Exception_UnknownFilterException(%s);
         }
-        $value = call_user_func($filter, $value);%s
+        $value = call_user_func($filter, %s);%s
     ';
+    const FILTER_FIRST_VALUE = '$this->resolveValue($value, $context)';
+    const FILTER_VALUE = '$value';
 
     /**
      * Generate Mustache Template variable filtering PHP source.
      *
+     * If the initial $value is a lambda it will be resolved before starting the filter chain.
+     *
      * @param string[] $filters Array of filters
      * @param int      $level
+     * @param bool     $first (default: false)
      *
      * @return string Generated filter PHP source
      */
-    private function getFilters(array $filters, $level)
+    private function getFilters(array $filters, $level, $first = true)
     {
         if (empty($filters)) {
             return '';
@@ -593,8 +598,9 @@ class Mustache_Compiler
         $findArg  = $this->getFindMethodArgs($method);
         $callable = $this->getCallable('$filter');
         $msg      = var_export($name, true);
+        $value    = $first ? self::FILTER_FIRST_VALUE : self::FILTER_VALUE;
 
-        return sprintf($this->prepare(self::FILTER, $level), $method, $filter, $findArg, $callable, $msg, $this->getFilters($filters, $level));
+        return sprintf($this->prepare(self::FILTER, $level), $method, $filter, $findArg, $callable, $msg, $value, $this->getFilters($filters, $level, false));
     }
 
     const LINE = '$buffer .= "\n";';

--- a/src/Mustache/Compiler.php
+++ b/src/Mustache/Compiler.php
@@ -333,15 +333,20 @@ class Mustache_Compiler
 
             if (%s) {
                 $source = %s;
-                $result = (string) call_user_func($value, $source, %s);
-                if (strpos($result, \'{{\') === false) {
-                    $buffer .= $result;
-                } else {
-                    $buffer .= $this->mustache
-                        ->loadLambda($result%s)
+                $value = call_user_func($value, $source, %s);
+
+                if (is_string($value)) {
+                    if (strpos($value, \'{{\') === false) {
+                        return $value;
+                    }
+
+                    return $this->mustache
+                        ->loadLambda($value%s)
                         ->renderInternal($context);
                 }
-            } elseif (!empty($value)) {
+            }
+
+            if (!empty($value)) {
                 $values = $this->isIterable($value) ? $value : array($value);
                 foreach ($values as $value) {
                     $context->push($value);

--- a/src/Mustache/Context.php
+++ b/src/Mustache/Context.php
@@ -125,18 +125,28 @@ class Mustache_Context
      * ... the `name` value is only searched for within the `child` value of the global Context, not within parent
      * Context frames.
      *
-     * @param string $id Dotted variable selector
+     * @param string $id              Dotted variable selector
+     * @param bool   $strictCallables (default: false)
      *
      * @return mixed Variable value, or '' if not found
      */
-    public function findDot($id)
+    public function findDot($id, $strictCallables = false)
     {
         $chunks = explode('.', $id);
         $first  = array_shift($chunks);
         $value  = $this->findVariableInStack($first, $this->stack);
 
+        // This wasn't really a dotted name, so we can just return the value.
+        if (empty($chunks)) {
+            return $value;
+        }
+
         foreach ($chunks as $chunk) {
-            if ($value === '') {
+            $isCallable = $strictCallables ? (is_object($value) && is_callable($value)) : (!is_string($value) && is_callable($value));
+
+            if ($isCallable) {
+                $value = $value();
+            } elseif ($value === '') {
                 return $value;
             }
 

--- a/src/Mustache/Template.php
+++ b/src/Mustache/Template.php
@@ -170,9 +170,15 @@ abstract class Mustache_Template
     protected function resolveValue($value, Mustache_Context $context)
     {
         if (($this->strictCallables ? is_object($value) : !is_string($value)) && is_callable($value)) {
-            return $this->mustache
-                ->loadLambda((string) call_user_func($value))
-                ->renderInternal($context);
+            $result = call_user_func($value);
+
+            if (is_string($result)) {
+                return $this->mustache
+                    ->loadLambda($result)
+                    ->renderInternal($context);
+            } else {
+                return $result;
+            }
         }
 
         return $value;

--- a/src/Mustache/Template.php
+++ b/src/Mustache/Template.php
@@ -176,9 +176,9 @@ abstract class Mustache_Template
                 return $this->mustache
                     ->loadLambda($result)
                     ->renderInternal($context);
-            } else {
-                return $result;
             }
+
+            return $result;
         }
 
         return $value;

--- a/test/Mustache/Test/FiveThree/Functional/FiltersTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/FiltersTest.php
@@ -184,4 +184,47 @@ EOS;
             })),
         );
     }
+
+    /**
+     * @group lambdas
+     * @dataProvider lambdaFiltersData
+     */
+    public function testLambdaFilters($tpl, $data, $expect)
+    {
+        $this->assertEquals($expect, $this->mustache->render($tpl, $data));
+    }
+
+    public function lambdaFiltersData()
+    {
+        $people = array(
+            (object) array('name' => 'Albert'),
+            (object) array('name' => 'Betty'),
+            (object) array('name' => 'Charles'),
+        );
+
+        $data = array(
+            'people' => $people,
+            'first_name' => function ($arr) {
+                return $arr[0]->name;
+            },
+            'last_name' => function ($arr) {
+                $last = end($arr);
+
+                return $last->name;
+            },
+            'all_names' => function ($arr) {
+                return implode(', ', array_map(function ($person) { return $person->name; }, $arr));
+            },
+            'first_person' => function ($arr) {
+                return $arr[0];
+            },
+        );
+
+        return array(
+            array('{{% FILTERS }}{{ people | first_name }}', $data, 'Albert'),
+            array('{{% FILTERS }}{{ people | last_name }}', $data, 'Charles'),
+            array('{{% FILTERS }}{{ people | all_names }}', $data, 'Albert, Betty, Charles'),
+            array('{{% FILTERS }}{{# people | first_person }}{{ name }}{{/ people }}', $data, 'Albert'),
+        );
+    }
 }

--- a/test/Mustache/Test/FiveThree/Functional/FiltersTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/FiltersTest.php
@@ -203,7 +203,13 @@ EOS;
         );
 
         $data = array(
+            'noop' => function ($value) {
+                return $value;
+            },
             'people' => $people,
+            'people_lambda' => function () use ($people) {
+                return $people;
+            },
             'first_name' => function ($arr) {
                 return $arr[0]->name;
             },
@@ -225,6 +231,8 @@ EOS;
             array('{{% FILTERS }}{{ people | last_name }}', $data, 'Charles'),
             array('{{% FILTERS }}{{ people | all_names }}', $data, 'Albert, Betty, Charles'),
             array('{{% FILTERS }}{{# people | first_person }}{{ name }}{{/ people }}', $data, 'Albert'),
+            array('{{% FILTERS }}{{# people_lambda | first_person }}{{ name }}{{/ people_lambda }}', $data, 'Albert'),
+            array('{{% FILTERS }}{{# people_lambda | noop | first_person }}{{ name }}{{/ people_lambda }}', $data, 'Albert'),
         );
     }
 }

--- a/test/Mustache/Test/FiveThree/Functional/HigherOrderSectionsTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/HigherOrderSectionsTest.php
@@ -60,6 +60,33 @@ class Mustache_Test_FiveThree_Functional_HigherOrderSectionsTest extends PHPUnit
 
         $this->assertEquals(sprintf('[[%s]]', $data['name']), $tpl->render($data));
     }
+
+    /**
+     * @dataProvider nonTemplateLambdasData
+     */
+    public function testNonTemplateLambdas($tpl, $data, $expect)
+    {
+        $this->assertEquals($expect, $this->mustache->render($tpl, $data));
+    }
+
+    public function nonTemplateLambdasData()
+    {
+        $data = array(
+            'lang' => 'en-US',
+            'people' => function () {
+                return array(
+                    (object) array('name' => 'Albert', 'lang' => 'en-GB'),
+                    (object) array('name' => 'Betty'),
+                    (object) array('name' => 'Charles'),
+                );
+            },
+        );
+
+        return array(
+            array("{{# people }} - {{ name }}\n{{/people}}", $data, " - Albert\n - Betty\n - Charles\n"),
+            array("{{# people }} - {{ name }}: {{ lang }}\n{{/people}}", $data, " - Albert: en-GB\n - Betty: en-US\n - Charles: en-US\n"),
+        );
+    }
 }
 
 class Mustache_Test_FiveThree_Functional_Foo


### PR DESCRIPTION
- Better support for lambda resolution in dotted names.
- Better support for lambda resolution in filter chains.
- Better support for complex lambda values (e.g. objects) as section context.

Fixes #415 (and more)

