### PR TITLE
Update Engine.php

### DIFF
--- a/src/Mustache/Engine.php
+++ b/src/Mustache/Engine.php
@@ -741,7 +741,7 @@ class Mustache_Engine
      *
      * @return Mustache_Template
      */
-    private function loadSource($source, Mustache_Cache $cache = null)
+    private function loadSource($source, ?Mustache_Cache $cache = null)
     {
         $className = $this->getTemplateClassName($source);
 


### PR DESCRIPTION
php 8.4 kompatibel
Implicitly marking parameter $cache as nullable is deprecated, the explicit nullable type must be used instead in