### PR TITLE
Update Parser.php

### DIFF
--- a/src/Mustache/Parser.php
+++ b/src/Mustache/Parser.php
@@ -72,7 +72,7 @@ class Mustache_Parser
      *
      * @return array Mustache Token parse tree
      */
-    private function buildTree(array &$tokens, array $parent = null)
+    private function buildTree(array &$tokens, ?array $parent = null)
     {
         $nodes = array();
 


### PR DESCRIPTION
php 8.4 kompatibel 
 Implicitly marking parameter $cache as nullable is deprecated, the explicit nullable type must be used instead in