### PR TITLE
Add a PSR-4 compatible load for non-composer users and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,18 @@ composer require mustache/mustache
 A quick example:
 
 ```php
-<?php
 $m = new \Mustache\Engine(['entity_flags' => ENT_QUOTES]);
 echo $m->render('Hello {{planet}}', ['planet' => 'World!']); // "Hello World!"
 ```
 
+or for non-composer users:
+
+```php
+require_once("/path/to/mustache/src/mustache.php");
+
+$m = new \Mustache\Engine(['entity_flags' => ENT_QUOTES]);
+echo $m->render('Today: {{date}}', ['date' => date('Y-m-d')]);
+```
 
 And a more in-depth example -- this is the canonical Mustache template:
 

--- a/src/mustache.php
+++ b/src/mustache.php
@@ -1,0 +1,29 @@
+<?php
+
+spl_autoload_register(function ($class) {
+    // project-specific namespace prefix
+    $prefix = 'Mustache\\';
+
+    // base directory for the namespace prefix
+    $base_dir = __DIR__ . '/';
+
+    // does the class use the namespace prefix?
+    $len = strlen($prefix);
+	if (strncmp($prefix, $class, $len) !== 0) {
+        // no, move to the next registered autoloader
+        return;
+    }
+
+    // get the relative class name
+    $relative_class = substr($class, $len);
+
+    // replace the namespace prefix with the base directory, replace namespace
+    // separators with directory separators in the relative class name, append
+    // with .php
+    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+
+    // if the file exists, require it
+    if (file_exists($file)) {
+        require $file;
+    }
+});


### PR DESCRIPTION
This should address #430. It ended up being simpler than I thought it would be. We do need an `include()` target so I went with `src/mustache.php` but it could be anything.

* `start.php`
* `loader.php`
* etc

This makes the path human consumable / parseable `require_once("/path/to/mustache/src/mustache.php");`. This should facilitate a user cloning the repository or downloading the latest release `.zip` file.